### PR TITLE
permessage deflate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stimulus_reflex (3.4.1)
       cable_ready (>= 4.5)
       nokogiri
+      permessage_deflate
       rack
       rails (>= 5.2)
       redis
@@ -81,7 +82,7 @@ GEM
     erubi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.8.7)
+    i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     loofah (2.9.0)
       crass (~> 1.0.2)
@@ -95,13 +96,14 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
-    nio4r (2.5.4)
+    nio4r (2.5.5)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
+    permessage_deflate (0.1.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -20,6 +20,7 @@ require "stimulus_reflex/broadcasters/broadcaster"
 require "stimulus_reflex/broadcasters/nothing_broadcaster"
 require "stimulus_reflex/broadcasters/page_broadcaster"
 require "stimulus_reflex/broadcasters/selector_broadcaster"
+require "stimulus_reflex/patches/client_socket"
 require "stimulus_reflex/utils/colorize"
 require "stimulus_reflex/logger"
 

--- a/lib/stimulus_reflex/patches/client_socket.rb
+++ b/lib/stimulus_reflex/patches/client_socket.rb
@@ -9,8 +9,8 @@ module ActionCable
       def initialize(env, event_target, event_loop, protocols)
         old_initialize(env, event_target, event_loop, protocols)
         deflate = PermessageDeflate.configure(
-          :level => Zlib::BEST_COMPRESSION,
-          :max_window_bits => 13
+          level: Zlib::BEST_COMPRESSION,
+          max_window_bits: 13
         )
         @driver.add_extension(deflate)
       end

--- a/lib/stimulus_reflex/patches/client_socket.rb
+++ b/lib/stimulus_reflex/patches/client_socket.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "permessage_deflate"
+
+module ActionCable
+  module Connection
+    class ClientSocket
+      alias_method :old_initialize, :initialize
+      def initialize(env, event_target, event_loop, protocols)
+        old_initialize(env, event_target, event_loop, protocols)
+        deflate = PermessageDeflate.configure(
+          :level => Zlib::BEST_COMPRESSION,
+          :max_window_bits => 13
+        )
+        @driver.add_extension(deflate)
+      end
+    end
+  end
+end

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rails", ">= 5.2"
   gem.add_dependency "redis"
   gem.add_dependency "cable_ready", ">= 4.5"
+  gem.add_dependency "permessage_deflate"
 
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "pry-nav"


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

My [currently failed] attempt to enable permessage_deflate as a monkey patch in SR.

Before:
<img width="271" alt="chrome_Dx9qik8Txm" src="https://user-images.githubusercontent.com/38150464/107194131-a8ffbd80-69bd-11eb-80dd-0bbca36f72d1.png">
After:
<img width="272" alt="chrome_DsMCPolonR" src="https://user-images.githubusercontent.com/38150464/107194157-b0bf6200-69bd-11eb-92a8-d5411d8266d8.png">

Despite promising initial results, it's shitting the bed with segfaults and I don't really know what seems to be the problem. Seeing "Invalid frame header" responses. What's weird is that some messages seem to manage to get through.

I've tried all of the possible values of `:max_window_bits` from 8 to 15.

My current solution is stolen verbatim from https://sapandiwakar.in/compressing-websocket-actioncable-frames-on-rails-with-permessage-deflate/ and was helped/influenced by https://github.com/faye/permessage-deflate-ruby

Anyhow, just sharing here in case someone has some detective juice.

## Why should this be added

Trying to enable brotli compression for WS traffic.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update