### PR TITLE
Fix cross-tab errors for piggybacked operations

### DIFF
--- a/javascript/reflexes.js
+++ b/javascript/reflexes.js
@@ -103,7 +103,10 @@ export const performOperations = data => {
       CableReady.perform(reflexOperations)
     }
   } else {
-    if (reflexes[Object.entries(data.operations)[0][1][0].reflexId])
+    if (
+      data.operations.length > 0 &&
+      reflexes[Object.entries(data.operations)[0][1][0].reflexId]
+    )
       CableReady.perform(data.operations)
   }
 }


### PR DESCRIPTION
# Bug Fix

## Description

Piggybacked operations would throw errors cross-tab in `performOperations` if operations were empty. 

![](https://cdn.discordapp.com/attachments/741684177837228042/848849804355698709/unknown.png)

## Why should this be added

Reflexes weren't broken, but it removes the odd console error above

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
- [X] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
