### PR TITLE
export uuidv4 function from main module

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -283,6 +283,7 @@ export default {
   initialize,
   register,
   useReflex,
+  uuidv4,
   get debug () {
     return Debug.value
   },


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement *proposal*

## Description

Export the `uuidv4` function from the main module.

## Why should this be added

I'm not 100% sure this *should* be added! But my logic was that if we expose this function as a convenience feature, it might save someone who needs to generate a uuid for any reason on the client from writing their own or importing a dependency.

It could be an over-reach. What do y'all think?

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update