### PR TITLE
refactor stream_name

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -4,11 +4,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
   attr_reader :reflex_data
 
   def stream_name
-    ids = connection.identifiers.map { |identifier| send(identifier).try(:id) || send(identifier) }
-    [
-      params[:channel],
-      ids.select(&:present?).join(";")
-    ].select(&:present?).join(":")
+    [params[:channel], connection.connection_identifier].join(":")
   end
 
   def subscribed

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,6 +44,26 @@ class TestModel
   end
 end
 
+module ActionCable
+  module Channel
+    class ConnectionStub
+      def connection_identifier
+        connection_gid identifiers.filter_map { |id| instance_variable_get("@#{id}") }
+      end
+
+      def connection_gid(ids)
+        ids.map do |o|
+          if o.respond_to? :to_gid_param
+            o.to_gid_param
+          else
+            o.to_s
+          end
+        end.sort.join(":")
+      end
+    end
+  end
+end    
+
 StimulusReflex.configuration.parent_channel = "ActionCable::Channel::Base"
 ActionCable::Server::Base.config.cable = {adapter: "test"}
 ActionCable::Server::Base.config.logger = Logger.new(nil)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,7 +48,7 @@ module ActionCable
   module Channel
     class ConnectionStub
       def connection_identifier
-        connection_gid identifiers.filter_map { |id| instance_variable_get("@#{id}") }
+        connection_gid identifiers.map { |id| instance_variable_get("@#{id}") }.compact
       end
 
       def connection_gid(ids)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,13 +52,7 @@ module ActionCable
       end
 
       def connection_gid(ids)
-        ids.map do |o|
-          if o.respond_to? :to_gid_param
-            o.to_gid_param
-          else
-            o.to_s
-          end
-        end.sort.join(":")
+        ids.map { |o| o.respond_to?(:to_gid_param) ? o.to_gid_param : o.to_s }.sort.join(":")
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,7 @@ module ActionCable
       end
     end
   end
-end    
+end
 
 StimulusReflex.configuration.parent_channel = "ActionCable::Channel::Base"
 ActionCable::Server::Base.config.cable = {adapter: "test"}


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

A simpler `stream_name`.

## Why should this be added

The way we figure out the SR `stream_name` has vestigal complexity from the days when we supported "rooms". There's no longer a reason to invent this here.

Also: someone could pick up the `id` of the current user from the current implementation. We should have been using `user.to_gid_param` the whole time!

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update