### PR TITLE
Add localization example to ApplicationReflex template

### DIFF
--- a/lib/generators/stimulus_reflex/templates/app/reflexes/application_reflex.rb.tt
+++ b/lib/generators/stimulus_reflex/templates/app/reflexes/application_reflex.rb.tt
@@ -1,24 +1,19 @@
 # frozen_string_literal: true
 
 class ApplicationReflex < StimulusReflex::Reflex
-  # Put application-wide Reflex behavior and callbacks in this file. 
-  #
-  # Example:
-  #
-  #   # If your ActionCable connection is: `identified_by :current_user`
-  #   delegate :current_user, to: :connection
-  #
-  # If you need localization in your reflexes you can also set
-  # the I18n locale here like so:
-  #
-  #   before_reflex :set_locale
-  #
-  #   def set_locale
-  #     I18n.locale = session[:locale]
-  #   end
-  #
-  # For this to work you will need to set `session[:locale]` in
-  # your ApplicationController.
+  # Put application-wide Reflex behavior and callbacks in this file.
   #
   # Learn more at: https://docs.stimulusreflex.com/rtfm/reflex-classes
+  #
+  # If your ActionCable connection is: `identified_by :current_user`
+  #   delegate :current_user, to: :connection
+  #
+  # If you need to localize your Reflexes, you can set the I18n locale here:
+  #
+  #   before_reflex do
+  #     I18n.locale = :fr
+  #   end
+  #
+  # For code examples, considerations and caveats, see:
+  # https://docs.stimulusreflex.com/rtfm/patterns#internationalization
 end

--- a/lib/generators/stimulus_reflex/templates/app/reflexes/application_reflex.rb.tt
+++ b/lib/generators/stimulus_reflex/templates/app/reflexes/application_reflex.rb.tt
@@ -8,5 +8,17 @@ class ApplicationReflex < StimulusReflex::Reflex
   #   # If your ActionCable connection is: `identified_by :current_user`
   #   delegate :current_user, to: :connection
   #
+  # If you need localization in your reflexes you can also set
+  # the I18n locale here like so:
+  #
+  #   before_reflex :set_locale
+  #
+  #   def set_locale
+  #     I18n.locale = session[:locale]
+  #   end
+  #
+  # For this to work you will need to set `session[:locale]` in
+  # your ApplicationController.
+  #
   # Learn more at: https://docs.stimulusreflex.com/rtfm/reflex-classes
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Needed to add full localization to all reflexes at the same time. This is an easier way than the current docs suggest, which is to create a helper method `with_locale` and wrap it around any code that needs it.

## Why should this be added

This would be helpful for anyone that needs to maintain an app that has multiple languages.

## Other

Feel free to suggest a change to the wording, English is my second language. I also went with the `before_reflex :name, def name` code style instead of `before_reflex do CODE end` style since I prefer that for my own code but you can change it if you wish.