### PR TITLE
add first line of stacktrace to console.log error in dev environment

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -25,7 +25,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
         if reflex
           reflex.rescue_with_handler(exception)
           puts error_message
-          reflex.broadcast_message subject: "error", data: data, error: exception
+          reflex.broadcast_message subject: "error", data: data, error: "#{exception} #{exception.backtrace.first if Rails.env.development?}"
         else
           puts error_message
 


### PR DESCRIPTION
# enhancement a bit more error to debug

## Description

I usually see errors on reflexes during development in the console.log first, so it would be nice to have a hint there,
where the error is coming from.

Therefore I added the first line of the stacktrace to the error info in the console.log for convenience.

## Why should this be added

Pure convenience, only done in dev environment

## Example output

![image](https://user-images.githubusercontent.com/194364/126541891-d6c22ae7-c9ec-458f-afe4-4569966cbfc6.png)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
