### PR TITLE
reflex render layout defaults to false

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -111,6 +111,8 @@ class StimulusReflex::Reflex
   end
 
   def render(*args)
+    options = args.extract_options!
+    args << options.reverse_merge!(layout: false)
     controller_class.renderer.new(connection.env.merge("SCRIPT_NAME" => "")).render(*args)
   end
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -112,7 +112,7 @@ class StimulusReflex::Reflex
 
   def render(*args)
     options = args.extract_options!
-    args << options.reverse_merge!(layout: false)
+    args << options.reverse_merge(layout: false)
     controller_class.renderer.new(connection.env.merge("SCRIPT_NAME" => "")).render(*args)
   end
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Reflex `render` method now defaults to `layout: false`.

## Why should this be added

Discord user @jsantos was having issues with AuthLogic when rendering a template using a Nothing Morph. It was determined that `render` calls initiated inside of Reflex classes should default to `layout: false`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
