### PR TITLE
Fix comment

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -88,7 +88,7 @@ const register = (controller, options = {}) => {
     // Invokes a server side reflex method.
     //
     // - target - the reflex target (full name of the server side reflex) i.e. 'ReflexClassName#method'
-    // - controllerElement - [optional] the element that triggered the reflex, defaults to this.element
+    // - reflexElement - [optional] the element that triggered the reflex, defaults to this.element
     // - options - [optional] an object that contains at least one of attrs, reflexId, selectors, resolveLate, serializeForm
     // - *args - remaining arguments are forwarded to the server side reflex method
     //


### PR DESCRIPTION
# Inline Method Doc Fix

## Description

I think we’re passing the `reflexElement` to `this.stimulate`, correct?

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
