### PR TITLE
reverse merge params into locals

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -114,6 +114,7 @@ class StimulusReflex::Reflex
 
   def render(*args)
     options = args.extract_options!
+    (options[:locals] ||= {}).reverse_merge!(params: params)
     args << options.reverse_merge(layout: false)
     controller_class.renderer.new(connection.env.merge("SCRIPT_NAME" => "")).render(*args)
   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

ActionDispatch automatically passes the `params` accessor into views as a local, but render inside of a Reflex does not.

This is a one-liner that adds params to the locals collection, but only if there's no previous value set for `params`.

## Why should this be added

Maintain consistency and principle of least surprise.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update