### PR TITLE
Add generator options to skip reflex and stimulus

### DIFF
--- a/lib/generators/stimulus_reflex/stimulus_reflex_generator.rb
+++ b/lib/generators/stimulus_reflex/stimulus_reflex_generator.rb
@@ -7,7 +7,7 @@ class StimulusReflexGenerator < Rails::Generators::NamedBase
 
   argument :name, type: :string, required: true, banner: "NAME"
   argument :actions, type: :array, default: [], banner: "action action"
-  class_options skip_stimulus: false, skip_application_reflex: false, skip_reflex: false, skip_application_controller: false
+  class_options skip_stimulus: false, skip_app_reflex: false, skip_reflex: false, skip_app_controller: false
 
   def execute
     actions.map!(&:underscore)
@@ -21,7 +21,7 @@ class StimulusReflexGenerator < Rails::Generators::NamedBase
   private
 
   def copy_application_files
-    template "app/reflexes/application_reflex.rb" unless options[:skip_application_reflex]
-    template "app/javascript/controllers/application_controller.js" unless options[:skip_application_controller]
+    template "app/reflexes/application_reflex.rb" unless options[:skip_app_reflex]
+    template "app/javascript/controllers/application_controller.js" unless options[:skip_app_controller]
   end
 end

--- a/lib/generators/stimulus_reflex/stimulus_reflex_generator.rb
+++ b/lib/generators/stimulus_reflex/stimulus_reflex_generator.rb
@@ -7,14 +7,14 @@ class StimulusReflexGenerator < Rails::Generators::NamedBase
 
   argument :name, type: :string, required: true, banner: "NAME"
   argument :actions, type: :array, default: [], banner: "action action"
-  class_options skip_stimulus: false, skip_application_reflex: false
+  class_options skip_stimulus: false, skip_application_reflex: false, skip_reflex: false, skip_application_controller: false
 
   def execute
     actions.map!(&:underscore)
 
     copy_application_files if behavior == :invoke
 
-    template "app/reflexes/%file_name%_reflex.rb"
+    template "app/reflexes/%file_name%_reflex.rb" unless options[:skip_reflex]
     template "app/javascript/controllers/%file_name%_controller.js" unless options[:skip_stimulus]
   end
 
@@ -22,6 +22,6 @@ class StimulusReflexGenerator < Rails::Generators::NamedBase
 
   def copy_application_files
     template "app/reflexes/application_reflex.rb" unless options[:skip_application_reflex]
-    template "app/javascript/controllers/application_controller.js"
+    template "app/javascript/controllers/application_controller.js" unless options[:skip_application_controller]
   end
 end

--- a/lib/generators/stimulus_reflex/stimulus_reflex_generator.rb
+++ b/lib/generators/stimulus_reflex/stimulus_reflex_generator.rb
@@ -7,6 +7,7 @@ class StimulusReflexGenerator < Rails::Generators::NamedBase
 
   argument :name, type: :string, required: true, banner: "NAME"
   argument :actions, type: :array, default: [], banner: "action action"
+  class_options skip_stimulus: false, skip_application_reflex: false
 
   def execute
     actions.map!(&:underscore)
@@ -14,13 +15,13 @@ class StimulusReflexGenerator < Rails::Generators::NamedBase
     copy_application_files if behavior == :invoke
 
     template "app/reflexes/%file_name%_reflex.rb"
-    template "app/javascript/controllers/%file_name%_controller.js"
+    template "app/javascript/controllers/%file_name%_controller.js" unless options[:skip_stimulus]
   end
 
   private
 
   def copy_application_files
-    template "app/reflexes/application_reflex.rb"
+    template "app/reflexes/application_reflex.rb" unless options[:skip_application_reflex]
     template "app/javascript/controllers/application_controller.js"
   end
 end

--- a/test/generators/stimulus_reflex_generator_test.rb
+++ b/test/generators/stimulus_reflex_generator_test.rb
@@ -25,8 +25,8 @@ class StimulusReflexGeneratorTest < Rails::Generators::TestCase
     assert_file "app/reflexes/posts_reflex.rb", /PostsReflex/
   end
 
-  test "skips stimulus controller and application reflex if option provided" do
-    run_generator %w[users --skip-stimulus --skip-reflex --skip-application-controller --skip-application-reflex]
+  test "skips stimulus controller and reflex if option provided" do
+    run_generator %w[users --skip-stimulus --skip-reflex --skip-app-controller --skip-app-reflex]
     assert_no_file "app/javascript/controllers/application_controller.js"
     assert_no_file "app/javascript/controllers/users_controller.js"
     assert_no_file "app/reflexes/application_reflex.rb"

--- a/test/generators/stimulus_reflex_generator_test.rb
+++ b/test/generators/stimulus_reflex_generator_test.rb
@@ -25,6 +25,14 @@ class StimulusReflexGeneratorTest < Rails::Generators::TestCase
     assert_file "app/reflexes/posts_reflex.rb", /PostsReflex/
   end
 
+  test "skips stimulus controller and applicatoin reflex if option provided" do
+    run_generator %w[users --skip-stimulus --skip-application-reflex]
+    assert_file "app/javascript/controllers/application_controller.js"
+    assert_no_file "app/javascript/controllers/users_controller.js"
+    assert_no_file "app/reflexes/application_reflex.rb"
+    assert_file "app/reflexes/users_reflex.rb", /UsersReflex/
+  end
+
   test "creates reflex with given reflex actions" do
     run_generator %w[User update do_stuff DoMoreStuff]
     assert_file "app/reflexes/user_reflex.rb" do |reflex|

--- a/test/generators/stimulus_reflex_generator_test.rb
+++ b/test/generators/stimulus_reflex_generator_test.rb
@@ -26,11 +26,11 @@ class StimulusReflexGeneratorTest < Rails::Generators::TestCase
   end
 
   test "skips stimulus controller and application reflex if option provided" do
-    run_generator %w[users --skip-stimulus --skip-application-reflex]
-    assert_file "app/javascript/controllers/application_controller.js"
+    run_generator %w[users --skip-stimulus --skip-reflex --skip-application-controller --skip-application-reflex]
+    assert_no_file "app/javascript/controllers/application_controller.js"
     assert_no_file "app/javascript/controllers/users_controller.js"
     assert_no_file "app/reflexes/application_reflex.rb"
-    assert_file "app/reflexes/users_reflex.rb", /UsersReflex/
+    assert_no_file "app/reflexes/users_reflex.rb"
   end
 
   test "creates reflex with given reflex actions" do

--- a/test/generators/stimulus_reflex_generator_test.rb
+++ b/test/generators/stimulus_reflex_generator_test.rb
@@ -25,7 +25,7 @@ class StimulusReflexGeneratorTest < Rails::Generators::TestCase
     assert_file "app/reflexes/posts_reflex.rb", /PostsReflex/
   end
 
-  test "skips stimulus controller and applicatoin reflex if option provided" do
+  test "skips stimulus controller and application reflex if option provided" do
     run_generator %w[users --skip-stimulus --skip-application-reflex]
     assert_file "app/javascript/controllers/application_controller.js"
     assert_no_file "app/javascript/controllers/users_controller.js"


### PR DESCRIPTION
# Feature

## Description

As requested by @julianrubisch in #541. A user might not require a stimulus controller or an application_reflex or both to be created or modified when using the generator. This PR adds four options `--skip-stimulus`, `--skip-reflex`, `--skip-app-controller` and `--skip-app-reflex` that helps the developer customize the files required.

Fixes #541

## Why should this be added

Everyone doesn't need the stimulus controller to be automatically created when using the generator. The added options can potentially save time by adding a simple flag to the generator instead of having to delete files or manually modify unwanted changes made by the generator.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
- [X] This is not a documentation update

Thank for your the opportunity to contribute again! ❤️ 
