### PR TITLE
overhaul Reflex logging

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -24,15 +24,15 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
 
         if reflex
           reflex.rescue_with_handler(exception)
-          puts error_message
+          reflex.logger&.error error_message
           reflex.error data: data, body: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
         else
-          puts error_message
+          reflex.logger&.error error_message
 
           if body.to_s.include? "No route matches"
             initializer_path = Rails.root.join("config", "initializers", "stimulus_reflex.rb")
 
-            puts <<~NOTE
+            reflex.logger&.warn <<~NOTE
               \e[33mNOTE: StimulusReflex failed to locate a matching route and could not re-render the page.
 
               If your app uses Rack middleware to rewrite part of the request path, you must enable those middleware modules in StimulusReflex.
@@ -62,14 +62,14 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           reflex.rescue_with_handler(exception)
           error = exception_with_backtrace(exception)
           reflex.error data: data, body: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
-          puts "\e[31mReflex failed to re-render: #{error[:message]} [#{reflex_data.url}]\e[0m\n#{error[:stack]}"
+          reflex.logger&.error "\e[31mReflex failed to re-render: #{error[:message]} [#{reflex_data.url}]\e[0m\n#{error[:stack]}"
         end
       end
     ensure
       if reflex
         commit_session(reflex)
         report_failed_basic_auth(reflex) if reflex.controller?
-        reflex.logger&.print
+        reflex.logger&.log_all_operations
       end
     end
   end
@@ -97,12 +97,12 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
     store.commit_session reflex.request, reflex.controller.response
   rescue => exception
     error = exception_with_backtrace(exception)
-    puts "\e[31mFailed to commit session! #{error[:message]}\e[0m\n#{error[:backtrace]}"
+    reflex.logger&.error "\e[31mFailed to commit session! #{error[:message]}\e[0m\n#{error[:backtrace]}"
   end
 
   def report_failed_basic_auth(reflex)
     if reflex.controller.response.status == 401
-      puts "\e[31mReflex failed to process controller action \"#{reflex.controller.class}##{reflex.controller.action_name}\" due to HTTP basic auth. Consider adding \"unless: -> { @stimulus_reflex }\" to the before_action or method responible for authentication.\e[0m"
+      reflex.logger&.error "\e[31mReflex failed to process controller action \"#{reflex.controller.class}##{reflex.controller.action_name}\" due to HTTP basic auth. Consider adding \"unless: -> { @stimulus_reflex }\" to the before_action or method responible for authentication.\e[0m"
     end
   end
 

--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -25,6 +25,11 @@ StimulusReflex.configure do |config|
 
   # config.parent_channel = "ApplicationCable::Channel"
 
+  # Override the logger that the StimulusReflex uses; default is Rails' logger
+  # eg. Logger.new(RAILS_ROOT + "/log/reflex.log")
+
+  # config.logger = Rails.logger
+
   # Customize server-side Reflex logging format, with optional colorization:
   # Available tokens: session_id, session_id_full, reflex_info, operation, reflex_id, reflex_id_full, mode, selector, operation_counter, connection_id, connection_id_full, timestamp
   # Available colors: red, green, yellow, blue, magenta, cyan, white

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -14,7 +14,7 @@ module StimulusReflex
   end
 
   class Configuration
-    attr_accessor :on_failed_sanity_checks, :on_new_version_available, :on_missing_default_urls, :parent_channel, :logging, :middleware
+    attr_accessor :on_failed_sanity_checks, :on_new_version_available, :on_missing_default_urls, :parent_channel, :logging, :logger, :middleware
 
     DEFAULT_LOGGING = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
@@ -24,6 +24,7 @@ module StimulusReflex
       @on_missing_default_urls = :warn
       @parent_channel = "ApplicationCable::Channel"
       @logging = DEFAULT_LOGGING
+      @logger = Rails.logger
       @middleware = ActionDispatch::MiddlewareStack.new
     end
   end

--- a/lib/stimulus_reflex/utils/logger.rb
+++ b/lib/stimulus_reflex/utils/logger.rb
@@ -2,18 +2,22 @@
 
 module StimulusReflex
   class Logger
+    attr_reader :logger
     attr_accessor :reflex, :current_operation
+
+    delegate :debug, :info, :warn, :error, :fatal, :unknown, to: :logger
 
     def initialize(reflex)
       @reflex = reflex
       @current_operation = 1
+      @logger = StimulusReflex.config.logger
     end
 
-    def print
+    def log_all_operations
       return unless config_logging.instance_of?(Proc)
 
       reflex.broadcaster.operations.each do
-        puts instance_eval(&config_logging) + "\e[0m"
+        logger.info instance_eval(&config_logging) + "\e[0m"
         @current_operation += 1
       end
     end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

SR now logs errors to `StimulusReflex.config.logger`, which defaults to `Rails.logger` but can be set in the SR initializer.

`debug` `info` `warn` `error` `fatal` `unknown` are all supported.

This PR should be completely transparent to most developers, except that they will now see Reflex logs (at `info` log level) in their Rails log.

## Why should this be added

The SR Logger class inexplicably used `puts` instead of writing to the Rails logger. This had the effect of making it so that Reflex "logs" show up in the server output even if logs are disabled, but don't show up in Rails logs even if logs are enabled. This is dumb!

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update