### PR TITLE
document body connection status classes

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -40,8 +40,8 @@ const initialize = (
 ) => {
   actionCable.set(consumer, params)
   setTimeout(() => {
-    document.body.classList.remove('sr-connected')
-    document.body.classList.add('sr-disconnected')
+    document.body.classList.remove('stimulus-reflex-connected')
+    document.body.classList.add('stimulus-reflex-disconnected')
     if (Deprecate.enabled && consumer)
       console.warn(
         "Deprecation warning: the next version of StimulusReflex will obtain a reference to consumer via the Stimulus application object.\nPlease add 'application.consumer = consumer' to your index.js after your Stimulus application has been established, and remove the consumer key from your StimulusReflex initialize() options object."

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -40,18 +40,18 @@ const initialize = (
 ) => {
   actionCable.set(consumer, params)
   setTimeout(() => {
+    document.body.classList.remove('sr-connected')
+    document.body.classList.add('sr-disconnected')
     if (Deprecate.enabled && consumer)
       console.warn(
         "Deprecation warning: the next version of StimulusReflex will obtain a reference to consumer via the Stimulus application object.\nPlease add 'application.consumer = consumer' to your index.js after your Stimulus application has been established, and remove the consumer key from your StimulusReflex initialize() options object."
       )
-  })
-  isolationMode.set(!!isolate)
-  setTimeout(() => {
     if (Deprecate.enabled && isolationMode.disabled)
       console.warn(
         'Deprecation warning: the next version of StimulusReflex will standardize isolation mode, and the isolate option will be removed.\nPlease update your applications to assume that every tab will be isolated.'
       )
   })
+  isolationMode.set(!!isolate)
   reflexes.app = application
   Schema.set(application)
   reflexes.app.register(
@@ -60,8 +60,6 @@ const initialize = (
   )
   Debug.set(!!debug)
   if (typeof deprecate !== 'undefined') Deprecate.set(deprecate)
-  document.body.classList.remove('sr-connected')
-  document.body.classList.add('sr-disconnected')
   const observer = new MutationObserver(setupDeclarativeReflexes)
   observer.observe(document.documentElement, {
     attributeFilter: [Schema.reflex, Schema.action],

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -60,6 +60,8 @@ const initialize = (
   )
   Debug.set(!!debug)
   if (typeof deprecate !== 'undefined') Deprecate.set(deprecate)
+  document.body.classList.remove('sr-connected')
+  document.body.classList.add('sr-disconnected')
   const observer = new MutationObserver(setupDeclarativeReflexes)
   observer.observe(document.documentElement, {
     attributeFilter: [Schema.reflex, Schema.action],

--- a/javascript/transports/action_cable.js
+++ b/javascript/transports/action_cable.js
@@ -24,14 +24,20 @@ const createSubscription = controller => {
 
 const connected = () => {
   subscriptionActive = true
-  document.body.classList.replace('sr-disconnected', 'sr-connected')
+  document.body.classList.replace(
+    'stimulus-reflex-disconnected',
+    'stimulus-reflex-connected'
+  )
   emitEvent('stimulus-reflex:connected')
   emitEvent('stimulus-reflex:action-cable:connected')
 }
 
 const rejected = () => {
   subscriptionActive = false
-  document.body.classList.replace('sr-connected', 'sr-disconnected')
+  document.body.classList.replace(
+    'stimulus-reflex-connected',
+    'stimulus-reflex-disconnected'
+  )
   emitEvent('stimulus-reflex:rejected')
   emitEvent('stimulus-reflex:action-cable:rejected')
   if (Debug.enabled) console.warn('Channel subscription was rejected.')
@@ -39,7 +45,10 @@ const rejected = () => {
 
 const disconnected = willAttemptReconnect => {
   subscriptionActive = false
-  document.body.classList.replace('srconnected', 'sr-disconnected')
+  document.body.classList.replace(
+    'stimulus-reflex-connected',
+    'stimulus-reflex-disconnected'
+  )
   emitEvent('stimulus-reflex:disconnected', willAttemptReconnect)
   emitEvent('stimulus-reflex:action-cable:disconnected', willAttemptReconnect)
 }

--- a/javascript/transports/action_cable.js
+++ b/javascript/transports/action_cable.js
@@ -24,20 +24,23 @@ const createSubscription = controller => {
 
 const connected = () => {
   subscriptionActive = true
-  emitEvent('stimulus-reflex:connected') // DEPRECATED and will be removed in the future
+  document.body.classList.replace('sr-disconnected', 'sr-connected')
+  emitEvent('stimulus-reflex:connected')
   emitEvent('stimulus-reflex:action-cable:connected')
 }
 
 const rejected = () => {
   subscriptionActive = false
-  emitEvent('stimulus-reflex:rejected') // DEPRECATED and will be removed in the future
+  document.body.classList.replace('sr-connected', 'sr-disconnected')
+  emitEvent('stimulus-reflex:rejected')
   emitEvent('stimulus-reflex:action-cable:rejected')
   if (Debug.enabled) console.warn('Channel subscription was rejected.')
 }
 
 const disconnected = willAttemptReconnect => {
   subscriptionActive = false
-  emitEvent('stimulus-reflex:disconnected', willAttemptReconnect) // DEPRECATED and will be removed in the future
+  document.body.classList.replace('srconnected', 'sr-disconnected')
+  emitEvent('stimulus-reflex:disconnected', willAttemptReconnect)
   emitEvent('stimulus-reflex:action-cable:disconnected', willAttemptReconnect)
 }
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

This is a very simple thing: the idea is to add an `stimulus-reflex-disconnected` CSS class to the document body element when SR initializes, and then swap it to `stimulus-reflex-connected` when the AC Connection is established. It'll switch back to "disconnected" if the Connection is rejected, as well.

I know that we've had discussions about this sort of functionality in the past, but as far as I know, we've never moved on it. I admit that I've forgotten why - the value seems self-evident, but perhaps I'm missing something glaring.

One other extremely minor detail is that I removed the textual deprecation warnings from the classic "library" events like `stimulus-reflex:connected` (as well as `rejected` and `disconnected`) as they were slated to be replaced by the more specific `stimulus-reflex:action-cable:connected`.

Coming in to add the classList functionality tonight, it occurred to me, well... what's the harm? So what if we support a general and specific event? In a future where we have multiple transports, there are scenarios where you might want the generic event for all transport types, or you might want specifically ActionCable, for example.

## Why should this be added

It really does seem like the easiest way to hide UI elements before ActionCable can connect, if that's a need you have.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update