### PR TITLE
fix gh action for standardrb

### DIFF
--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - uses: actions/cache@v1
       with:
         path: vendor/bundle


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Enhancement

## Description
Noticed the standardrb GH action was using a [deprecated action](https://github.com/actions/setup-ruby) and replaced with [recommended one.](https://github.com/ruby/setup-ruby)

## Why should this be added

Always advantageous to stay updated and remove unmaintained actions. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Hope this PR is okay :heart:

