### PR TITLE
serialize forms with multiple, non-unique array elements

### DIFF
--- a/javascript/test/utils.serializeForm.test.js
+++ b/javascript/test/utils.serializeForm.test.js
@@ -304,6 +304,21 @@ describe('formSerialize', () => {
         'people%5B2%5D%5Bname%5D=bubba&people%5B2%5D%5Bage%5D=15&people%5B0%5D%5Bname%5D=fred&people%5B0%5D%5Bage%5D=12&people%5B1%5D%5Bname%5D=bob&people%5B1%5D%5Bage%5D=14&people%5B%5D%5Bname%5D=frank&people%5B3%5D%5Bage%5D=2'
       assert.equal(actual, expected)
     })
+
+    it('should serialize forms with multiple, non-unique array elements', () => {
+      const dom = new JSDOM(
+        '<form>' +
+          '<input type="text" name="post[test][]" value="a"/>' +
+          '<input type="text" name="post[test][]" value="a"/>' +
+          '<input type="text" name="post[test][]" value="b"/>' +
+          '</form>'
+      )
+      const form = dom.window.document.querySelector('form')
+      const actual = serializeForm(form, { w: dom.window })
+      const expected =
+        'post%5Btest%5D%5B%5D=a&post%5Btest%5D%5B%5D=a&post%5Btest%5D%5B%5D=b'
+      assert.equal(actual, expected)
+    })
   })
 
   context('<select>', () => {

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -35,8 +35,7 @@ const serializeForm = (form, options = {}) => {
       )}`
     )
   }
-
-  return Array.from(new Set(data)).join('&')
+  return Array.from(data).join('&')
 }
 
 const camelize = (value, uppercaseFirstLetter = true) => {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Serialized forms can now contain arrays with non-unique values.

Fixes #555

## Why should this be added

As @thewatts [demonstrated](https://github.com/thewatts/reflex-params-example) the `serializeForm` method was rejecting non-unique form array values. This created an outcome different from what the client-side `FormData` object produces, and different from what you'd get if you submitted the form to ActionDispatch.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update