### PR TITLE
When searching a controller based off a reflex name, ignore hyphens

### DIFF
--- a/javascript/controllers.js
+++ b/javascript/controllers.js
@@ -37,7 +37,7 @@ const findControllerByReflexName = (reflexName, controllers) => {
 
     return (
       extractReflexName(reflexName).toLowerCase() ===
-      controller.identifier.toLowerCase()
+      controller.identifier.replace('-', '').toLowerCase()
     )
   })
 

--- a/javascript/controllers.js
+++ b/javascript/controllers.js
@@ -36,8 +36,10 @@ const findControllerByReflexName = (reflexName, controllers) => {
     if (!controller.identifier) return
 
     return (
-      extractReflexName(reflexName).toLowerCase() ===
-      controller.identifier.replace('-', '').toLowerCase()
+      extractReflexName(reflexName)
+        .replace(/([a-z0–9])([A-Z])/g, '$1-$2')
+        .replace(/(::)/g, '--')
+        .toLowerCase() === controller.identifier
     )
   })
 


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bug fix

## Description
Stimulus controller identifiers are using kebab-case, while Reflex class name are CamelCase, which means if the controller and reflex combo are 2 or more words the controller lookup for client callbacks will fail. When it fails, it usually defaults to the first registered controller (https://github.com/stimulusreflex/stimulus_reflex/blob/master/javascript/controllers.js#L44).
It will then fail to call the callbacks if the first controller registered is a different one.

## Why should this be added

It is not farfetched to have more than one controller in the page, and also to have a controller name being more than 1 word. This combo lead to unexpected behaviour like calling the wrong callbacks.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
