### PR TITLE
emit custom life-cycle events

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -236,6 +236,7 @@ const dispatchLifecycleEvent = (
   const { target } = controllerElement.reflexData[reflexId] || {}
   const controller = controllerElement.reflexController[reflexId] || {}
   const event = `stimulus-reflex:${stage}`
+  const action = `${event}:${target.split('#')[1]}`
   const detail = {
     reflex: target,
     controller,
@@ -243,11 +244,15 @@ const dispatchLifecycleEvent = (
     element: reflexElement,
     payload
   }
+  const options = { bubbles: true, cancelable: false, detail }
 
-  controllerElement.dispatchEvent(
-    new CustomEvent(event, { bubbles: true, cancelable: false, detail })
-  )
-  if (window.jQuery) window.jQuery(controllerElement).trigger(event, detail)
+  controllerElement.dispatchEvent(new CustomEvent(event, options))
+  controllerElement.dispatchEvent(new CustomEvent(action, options))
+
+  if (window.jQuery) {
+    window.jQuery(controllerElement).trigger(event, detail)
+    window.jQuery(controllerElement).trigger(action, detail)
+  }
 }
 
 export { dispatchLifecycleEvent }

--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -202,6 +202,8 @@ document.addEventListener(
 //
 // - reflexId - the UUIDv4 which uniquely identifies the Reflex
 //
+// - payload - optional Reflex return value
+//
 const dispatchLifecycleEvent = (
   stage,
   reflexElement,


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Feature

## Description

Adds custom events so that developers can choose to handle specific Reflex actions. Easier to explain with an example:

```js
// today, we don't know which Reflex action this is for
document.addEventListener('stimulus-reflex:after', event => console.log(event))

// this PR makes it possible to know that it was for the `status` action
document.addEventListener('stimulus-reflex:after:status', event => console.log(event))
```
## Why should this be added

Today, we emit events for Reflex actions in a generic way: https://docs.stimulusreflex.com/rtfm/lifecycle#life-cycle-events

Discussion with Lorenzo made me realize that we could easily have SR emit both generic and custom events: https://discordapp.com/channels/629472241427415060/733725826411135107/907294392946130985

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update