### PR TITLE
suppress logging

### DIFF
--- a/javascript/callbacks.js
+++ b/javascript/callbacks.js
@@ -3,7 +3,6 @@ import reflexes from './reflexes'
 import { XPathToElement } from './utils'
 import { dispatchLifecycleEvent } from './lifecycle'
 import Log from './log'
-import Debug from './debug'
 
 const beforeDOMUpdate = event => {
   const { stimulusReflex, payload } = event.detail || {}
@@ -52,7 +51,7 @@ const afterDOMUpdate = event => {
 
   reflex.completedOperations++
 
-  if (Debug.enabled) Log.success(event, false)
+  Log.success(event, false)
 
   if (reflex.completedOperations < reflex.totalOperations) return
 
@@ -128,7 +127,7 @@ const routeReflexEvent = event => {
 const nothing = (event, payload, promise, reflex, reflexElement) => {
   reflex.finalStage = 'after'
 
-  if (Debug.enabled) Log.success(event, false)
+  Log.success(event, false)
 
   setTimeout(() =>
     promise.resolve({
@@ -145,7 +144,7 @@ const nothing = (event, payload, promise, reflex, reflexElement) => {
 const halted = (event, payload, promise, reflex, reflexElement) => {
   reflex.finalStage = 'halted'
 
-  if (Debug.enabled) Log.success(event, true)
+  Log.success(event, true)
 
   setTimeout(() =>
     promise.resolve({
@@ -162,7 +161,7 @@ const halted = (event, payload, promise, reflex, reflexElement) => {
 const error = (event, payload, promise, reflex, reflexElement) => {
   reflex.finalStage = 'after'
 
-  if (Debug.enabled) Log.error(event)
+  Log.error(event)
 
   setTimeout(() =>
     promise.reject({

--- a/javascript/log.js
+++ b/javascript/log.js
@@ -1,4 +1,5 @@
 import reflexes from './reflexes'
+import Debug from './debug'
 
 const request = (
   reflexId,
@@ -8,7 +9,9 @@ const request = (
   element,
   controllerElement
 ) => {
-  reflexes[reflexId].timestamp = new Date()
+  const reflex = reflexes[reflexId]
+  if (Debug.disabled || reflex.promise.data.suppressLogging) return
+  reflex.timestamp = new Date()
   console.log(`\u2191 stimulus \u2191 ${target}`, {
     reflexId,
     args,
@@ -23,6 +26,7 @@ const success = (event, halted) => {
   const { selector, payload } = detail || {}
   const { reflexId, target, morph } = detail.stimulusReflex || {}
   const reflex = reflexes[reflexId]
+  if (Debug.disabled || reflex.promise.data.suppressLogging) return
   const progress =
     reflex.totalOperations > 1
       ? ` ${reflex.completedOperations}/${reflex.totalOperations}`
@@ -46,6 +50,7 @@ const error = event => {
   const { detail } = event || {}
   const { reflexId, target, payload } = detail.stimulusReflex || {}
   const reflex = reflexes[reflexId]
+  if (Debug.disabled || reflex.promise.data.suppressLogging) return
   const duration = reflex.timestamp
     ? `in ${new Date() - reflex.timestamp}ms`
     : 'CLONED'

--- a/javascript/reflex_data.js
+++ b/javascript/reflex_data.js
@@ -100,6 +100,14 @@ export default class ReflexData {
       : false
   }
 
+  get suppressLogging () {
+    return (
+      this.options['suppressLogging'] ||
+      this.reflexElement.attributes[Schema.reflexSuppressLogging] ||
+      false
+    )
+  }
+
   valueOf () {
     return {
       attrs: this.attrs,
@@ -107,6 +115,7 @@ export default class ReflexData {
       selectors: this.selectors,
       reflexId: this.reflexId,
       resolveLate: this.resolveLate,
+      suppressLogging: this.suppressLogging,
       xpathController: this.xpathController,
       xpathElement: this.xpathElement,
       inner_html: this.innerHTML,

--- a/javascript/schema.js
+++ b/javascript/schema.js
@@ -2,6 +2,7 @@ const defaultSchema = {
   reflexAttribute: 'data-reflex',
   reflexPermanentAttribute: 'data-reflex-permanent',
   reflexRootAttribute: 'data-reflex-root',
+  reflexSuppressLoggingAttribute: 'data-reflex-suppress-logging',
   reflexDatasetAttribute: 'data-reflex-dataset',
   reflexDatasetAllAttribute: 'data-reflex-dataset-all',
   reflexSerializeFormAttribute: 'data-reflex-serialize-form',

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -124,6 +124,7 @@ const register = (controller, options = {}) => {
             'reflexId',
             'resolveLate',
             'serializeForm',
+            'suppressLogging',
             'includeInnerHTML',
             'includeTextContent'
           ].includes(key)
@@ -206,16 +207,14 @@ const register = (controller, options = {}) => {
 
       const promise = registerReflex(reflexData.valueOf())
 
-      if (Debug.enabled) {
-        Log.request(
-          reflexId,
-          target,
-          args,
-          this.context.scope.identifier,
-          reflexElement,
-          controllerElement
-        )
-      }
+      Log.request(
+        reflexId,
+        target,
+        args,
+        this.context.scope.identifier,
+        reflexElement,
+        controllerElement
+      )
 
       return promise
     },

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ClientAttributes = Struct.new(:reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, keyword_init: true)
+ClientAttributes = Struct.new(:reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :suppress_logging, keyword_init: true)
 
 class StimulusReflex::Reflex
   include ActiveSupport::Rescuable
@@ -16,7 +16,7 @@ class StimulusReflex::Reflex
   delegate :connection, :stream_name, to: :channel
   delegate :controller_class, :flash, :session, to: :request
   delegate :broadcast, :halted, :error, to: :broadcaster
-  delegate :reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, to: :client_attributes
+  delegate :reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :suppress_logging, to: :client_attributes
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
     if is_a? CableReady::Broadcaster
@@ -37,8 +37,8 @@ class StimulusReflex::Reflex
     @method_name = method_name
     @params = params
     @broadcaster = StimulusReflex::PageBroadcaster.new(self)
-    @logger = StimulusReflex::Logger.new(self)
     @client_attributes = ClientAttributes.new(client_attributes)
+    @logger = suppress_logging ? nil : StimulusReflex::Logger.new(self)
     @cable_ready = StimulusReflex::CableReadyChannels.new(stream_name, reflex_id)
     @payload = {}
     @headers = {}

--- a/lib/stimulus_reflex/reflex_data.rb
+++ b/lib/stimulus_reflex/reflex_data.rb
@@ -41,6 +41,10 @@ class StimulusReflex::ReflexData
     data["permanentAttributeName"]
   end
 
+  def suppress_logging
+    data["suppressLogging"]
+  end
+
   def form_data
     Rack::Utils.parse_nested_query(data["formData"])
   end

--- a/lib/stimulus_reflex/reflex_factory.rb
+++ b/lib/stimulus_reflex/reflex_factory.rb
@@ -16,7 +16,8 @@ class StimulusReflex::ReflexFactory
           xpath_controller: reflex_data.xpath_controller,
           xpath_element: reflex_data.xpath_element,
           reflex_controller: reflex_data.reflex_controller,
-          permanent_attribute_name: reflex_data.permanent_attribute_name
+          permanent_attribute_name: reflex_data.permanent_attribute_name,
+          suppress_logging: reflex_data.suppress_logging
         })
     end
 

--- a/test/broadcasters/nothing_broadcaster_test.rb
+++ b/test/broadcasters/nothing_broadcaster_test.rb
@@ -11,6 +11,7 @@ class StimulusReflex::NothingBroadcasterTest < StimulusReflex::BroadcasterTestCa
       "operations" => [
         {
           "name" => "stimulus-reflex:morph-nothing",
+          "selector" => nil,
           "payload" => {},
           "stimulusReflex" => {
             "some" => "data",


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Feature

## Description

While it's already possible to suppress server-side logging on a per-Reflex basis, it was previously impossible to suppress client-side logging on a per-Reflex basis. This PR provides the ability to suppress client and server logging for a single Reflex action.

It can be specified as an attribute:

```html
<button data-reflex="click->Example#foo" data-reflex-suppress-logging>No logs</button>
```
or as an option passed to `stimulate`:
```js
this.stimulate('Example#foo', {suppressLogging: true})
```

## Why should this be added

A lot of logs in a row can create clutter, especially if you're dealing with a difficult timing scenario or side effects.

A massive number of logs can be a huge performance hit, making it difficult to test frequently sampled input or deal with a game loop.

Also, sometimes you just want to suppress logging. 🤷

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update