### PR TITLE
Fall back to empty siblings list if no parentNode is present

### DIFF
--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -85,7 +85,7 @@ const elementToXPath = element => {
   if (element === document.body) return '/html/body'
 
   let ix = 0
-  const siblings = element.parentNode.childNodes
+  const siblings = element.parentNode ? element.parentNode.childNodes : []
 
   for (var i = 0; i < siblings.length; i++) {
     const sibling = siblings[i]


### PR DESCRIPTION
# Bug Fix

## Description

When combining `updates_for` with a page or selector morph, a race condition could occur where SR's `elementToXPath` would try to parse a document fragment that's not yet connected to the DOM as part of `updates_for`'s morphing process. Traversing up the tree, such an element would have no `parentNode` and thus no siblings.

This PR fixes it by falling back to an empty siblings array should that occur.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
