### PR TITLE
Updated gemspec to specific Rails gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     stimulus_reflex (3.5.0.pre8)
       actioncable (>= 5.2)
       actionpack (>= 5.2)
+      actionview (>= 5.2)
       activesupport (>= 5.2)
       cable_ready (= 5.0.0.pre8)
       nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,12 @@ PATH
   remote: .
   specs:
     stimulus_reflex (3.5.0.pre8)
+      actioncable (>= 5.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       cable_ready (= 5.0.0.pre8)
       nokogiri
       rack
-      rails (>= 5.2)
       redis
 
 GEM
@@ -256,9 +258,10 @@ DEPENDENCIES
   mocha
   pry
   pry-nav
+  rails (>= 5.2)
   rake
   standardrb (~> 1.0)
   stimulus_reflex!
 
 BUNDLED WITH
-   2.2.31
+   2.2.33

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../lib/stimulus_reflex/version", __FILE__)
+require File.expand_path("lib/stimulus_reflex/version", __dir__)
 
 Gem::Specification.new do |gem|
   gem.name = "stimulus_reflex"
@@ -32,17 +32,22 @@ Gem::Specification.new do |gem|
   gem.files = Dir["app/**/*", "lib/**/*", "bin/*", "[A-Z]*"]
   gem.test_files = Dir["test/**/*.rb"]
 
-  gem.add_dependency "rack"
-  gem.add_dependency "nokogiri"
-  gem.add_dependency "rails", ">= 5.2"
-  gem.add_dependency "redis"
+  rails_version = ">= 5.2"
+  gem.add_dependency "actioncable", rails_version
+  gem.add_dependency "actionpack", rails_version
+  gem.add_dependency "activesupport", rails_version
+
   gem.add_dependency "cable_ready", "5.0.0.pre8"
+  gem.add_dependency "nokogiri"
+  gem.add_dependency "rack"
+  gem.add_dependency "redis"
 
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "github_changelog_generator"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
+  gem.add_development_dependency "rails", rails_version
   gem.add_development_dependency "rake"
   gem.add_development_dependency "standardrb", "~> 1.0"
 end

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |gem|
   rails_version = ">= 5.2"
   gem.add_dependency "actioncable", rails_version
   gem.add_dependency "actionpack", rails_version
+  gem.add_dependency "actionview", rails_version
   gem.add_dependency "activesupport", rails_version
 
   gem.add_dependency "cable_ready", "5.0.0.pre8"


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

Limit gem dependencies to only the Rails gems that we directly depend upon.

## Why should this be added

Most apps don't require the full suite of Rails gems, and can avoid installing them to save CI and deploy time. This gem, however, had a dependency on the Rails meta-gem which ended up installing them all anyways.

I'm not sure how to really test this, since the dummy app uses all of Rails. I grep'd through ./lib to see what parts of Rails were being used, but that might not be comprehensive.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
