### PR TITLE
Fix logger when :logging is nil

### DIFF
--- a/lib/stimulus_reflex/utils/logger.rb
+++ b/lib/stimulus_reflex/utils/logger.rb
@@ -27,6 +27,8 @@ module StimulusReflex
     def config_logging
       return @config_logging if @config_logging
 
+      return unless StimulusReflex.config.logging.instance_of?(Proc)
+
       StimulusReflex.config.logging.binding.eval("using StimulusReflex::Utils::Colorize")
       @config_logging = StimulusReflex.config.logging
     end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

When upgrading to 3.5.0.pre-8, our Sentry instance started blowing up with logging errors (~250k in one day!). The error reports looked like this: 

```
NoMethodError: private method `binding' called for nil:NilClass
Did you mean?  __binding__
  from stimulus_reflex (3.5.0.pre8) lib/stimulus_reflex/utils/logger.rb:30:in `config_logging'
  ...
```

Tracing this back to our configuration, we had configured the `logging` to nil:

```rb
StimulusReflex.configure do |config|
  config.logging = nil
end
```

The way the logger is written, it correctly ignores logging if `@config_logging` is not a proc, but the `config_logging` method expects `StimulusReflex.config.logging` to respond with something responds to `.binding`... which `nil` doesn't.

This PR just adds a check in that method to make sure the logging configuration is a proc before continuing.


Fixes #574 

## Why should this be added

To not throw errors when electing to have no logging proc.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
