### PR TITLE
Add `.rake` to gemspec `files` glob pattern

### DIFF
--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   }
 
   gem.files = Dir[
-    "lib/**/*.rb",
+    "lib/**/*.{rb,rake}",
     "app/**/*.rb",
     "app/assets/javascripts/*",
     "bin/*",


### PR DESCRIPTION
# Type of PR

Bug Fix

## Description

In the process of releasing `3.5.0.pre9` we harmonized the `gemspec` `files` glob pattern with the one of CableReady. In that process we changed `lib/**/*` to `lib/**/*.rb` and with that losing the inclusion of the `install.rake` file. This one is needed in order to run the install rake task.

## Why should this be added

This PR adds the `.rake` file extension to the `files` glob pattern in the gemspec so that the `install.rake` file is included in the bundled gem again.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
