### PR TITLE
conditional operator breaks webpack in some cases

### DIFF
--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -85,7 +85,8 @@ const elementToXPath = element => {
   if (element === document.body) return '/html/body'
 
   let ix = 0
-  const siblings = element?.parentNode ? element.parentNode.childNodes : []
+  const siblings =
+    element && element.parentNode ? element.parentNode.childNodes : []
 
   for (var i = 0; i < siblings.length; i++) {
     const sibling = siblings[i]


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Modifies `elementToXPath` to not use optional chaining operator.

## Why should this be added

Some permutations of Webpacker choke on compiled SR bundles that include `?.` syntax for safe navigation. While it's possible to mitigate this with the addition of an `acorn` resolution, the single use of the operator is not enough of a benefit to justify significant further exploration at this time.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
