### PR TITLE
connection status class

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -112,7 +112,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
   end
 
   def commit_session(reflex)
-    store = reflex.request.session.instance_variable_get("@by")
+    store = reflex.request.session.instance_variable_get(:@by)
     store.commit_session reflex.request, reflex.controller.response
   rescue => exception
     error = exception_with_backtrace(exception)

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -41,16 +41,10 @@ const initialize = (
   application,
   { controller, consumer, debug, params, isolate, deprecate } = {}
 ) => {
-  ActionCableTransport.set(consumer, params)
+  ActionCableTransport.initialize(consumer, params)
   document.addEventListener(
     'DOMContentLoaded',
     () => {
-      document.body.classList.remove('stimulus-reflex-connected')
-      document.body.classList.add('stimulus-reflex-disconnected')
-      if (Deprecate.enabled && consumer)
-        console.warn(
-          "Deprecation warning: the next version of StimulusReflex will obtain a reference to consumer via the Stimulus application object.\nPlease add 'application.consumer = consumer' to your index.js after your Stimulus application has been established, and remove the consumer key from your StimulusReflex initialize() options object."
-        )
       if (Deprecate.enabled && IsolationMode.disabled)
         console.warn(
           'Deprecation warning: the next version of StimulusReflex will standardize isolation mode, and the isolate option will be removed.\nPlease update your applications to assume that every tab will be isolated.'
@@ -260,8 +254,4 @@ document.addEventListener('cable-ready:after-inner-html', afterDOMUpdate)
 document.addEventListener('cable-ready:after-morph', afterDOMUpdate)
 window.addEventListener('load', setupDeclarativeReflexes)
 
-export {
-  initialize,
-  register,
-  useReflex
-}
+export { initialize, register, useReflex }

--- a/javascript/transports/action_cable.js
+++ b/javascript/transports/action_cable.js
@@ -1,10 +1,26 @@
 import { createConsumer } from '@rails/actioncable'
 import { received } from '../reflexes'
 import { emitEvent } from '../utils'
+import Deprecate from '../deprecate'
 
 let consumer
 let params
 let subscriptionActive
+
+const initialize = (consumerValue, paramsValue) => {
+  consumer = consumerValue
+  params = paramsValue
+  document.addEventListener('DOMContentLoaded', () => {
+    subscriptionActive = false
+    connectionStatusClass()
+    if (Deprecate.enabled && consumer)
+      console.warn(
+        "Deprecation warning: the next version of StimulusReflex will obtain a reference to consumer via the Stimulus application object.\nPlease add 'application.consumer = consumer' to your index.js after your Stimulus application has been established, and remove the consumer key from your StimulusReflex initialize() options object."
+      )
+  })
+  document.addEventListener('turbolinks:load', connectionStatusClass)
+  document.addEventListener('turbo:load', connectionStatusClass)
+}
 
 const createSubscription = controller => {
   consumer = consumer || controller.application.consumer || createConsumer()
@@ -24,20 +40,14 @@ const createSubscription = controller => {
 
 const connected = () => {
   subscriptionActive = true
-  document.body.classList.replace(
-    'stimulus-reflex-disconnected',
-    'stimulus-reflex-connected'
-  )
+  connectionStatusClass()
   emitEvent('stimulus-reflex:connected')
   emitEvent('stimulus-reflex:action-cable:connected')
 }
 
 const rejected = () => {
   subscriptionActive = false
-  document.body.classList.replace(
-    'stimulus-reflex-connected',
-    'stimulus-reflex-disconnected'
-  )
+  connectionStatusClass()
   emitEvent('stimulus-reflex:rejected')
   emitEvent('stimulus-reflex:action-cable:rejected')
   if (Debug.enabled) console.warn('Channel subscription was rejected.')
@@ -45,12 +55,31 @@ const rejected = () => {
 
 const disconnected = willAttemptReconnect => {
   subscriptionActive = false
-  document.body.classList.replace(
-    'stimulus-reflex-connected',
-    'stimulus-reflex-disconnected'
-  )
+  connectionStatusClass()
   emitEvent('stimulus-reflex:disconnected', willAttemptReconnect)
   emitEvent('stimulus-reflex:action-cable:disconnected', willAttemptReconnect)
+}
+
+const connectionStatusClass = () => {
+  const list = document.body.classList
+  if (
+    !(
+      list.contains('stimulus-reflex-connected') ||
+      list.contains('stimulus-reflex-disconnected')
+    )
+  ) {
+    list.add(
+      subscriptionActive
+        ? 'stimulus-reflex-connected'
+        : 'stimulus-reflex-disconnected'
+    )
+    return
+  }
+  if (subscriptionActive) {
+    list.replace('stimulus-reflex-disconnected', 'stimulus-reflex-connected')
+  } else {
+    list.replace('stimulus-reflex-connected', 'stimulus-reflex-disconnected')
+  }
 }
 
 export default {
@@ -63,8 +92,6 @@ export default {
   connected,
   rejected,
   disconnected,
-  set (consumerValue, paramsValue) {
-    consumer = consumerValue
-    params = paramsValue
-  }
+  connectionStatusClass,
+  initialize
 }

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -31,7 +31,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = BeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 6, reflex.instance_variable_get("@count")
+    assert_equal 6, reflex.instance_variable_get(:@count)
   end
 
   test "before_reflex with block works" do
@@ -47,7 +47,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = BeforeBlockCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 6, reflex.instance_variable_get("@count")
+    assert_equal 6, reflex.instance_variable_get(:@count)
   end
 
   test "basic after_reflex works" do
@@ -67,7 +67,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = AfterCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 1, reflex.instance_variable_get("@count")
+    assert_equal 1, reflex.instance_variable_get(:@count)
   end
 
   test "after_reflex with block works" do
@@ -83,7 +83,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = AfterBlockCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 1, reflex.instance_variable_get("@count")
+    assert_equal 1, reflex.instance_variable_get(:@count)
   end
 
   test "basic around_reflex works" do
@@ -105,7 +105,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = AroundCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 14, reflex.instance_variable_get("@count")
+    assert_equal 14, reflex.instance_variable_get(:@count)
   end
 
   test "execute methods in order" do
@@ -133,7 +133,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = CallbackOrderReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 3, reflex.instance_variable_get("@count")
+    assert_equal 3, reflex.instance_variable_get(:@count)
   end
 
   test "basic if option works" do
@@ -173,7 +173,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = IfCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 23, reflex.instance_variable_get("@count")
+    assert_equal 23, reflex.instance_variable_get(:@count)
   end
 
   test "if option with proc/lambda works" do
@@ -205,7 +205,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = IfProcCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 23, reflex.instance_variable_get("@count")
+    assert_equal 23, reflex.instance_variable_get(:@count)
   end
 
   test "basic unless option works" do
@@ -245,7 +245,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = UnlessCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 23, reflex.instance_variable_get("@count")
+    assert_equal 23, reflex.instance_variable_get(:@count)
   end
 
   test "unless option with proc/lambda works" do
@@ -277,7 +277,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = UnlessProcCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 23, reflex.instance_variable_get("@count")
+    assert_equal 23, reflex.instance_variable_get(:@count)
   end
 
   test "only option works" do
@@ -311,7 +311,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = OnlyCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :decrement, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:decrement)
-    assert_equal(-8, reflex.instance_variable_get("@count"))
+    assert_equal(-8, reflex.instance_variable_get(:@count))
   end
 
   test "except option works" do
@@ -345,11 +345,11 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = ExceptCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 6, reflex.instance_variable_get("@count")
+    assert_equal 6, reflex.instance_variable_get(:@count)
 
     reflex = ExceptCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :decrement, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:decrement)
-    assert_equal(-8, reflex.instance_variable_get("@count"))
+    assert_equal(-8, reflex.instance_variable_get(:@count))
   end
 
   test "skip_before_reflex works" do
@@ -383,7 +383,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = SkipBeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 6, reflex.instance_variable_get("@count")
+    assert_equal 6, reflex.instance_variable_get(:@count)
   end
 
   test "skip_after_reflex works" do
@@ -417,7 +417,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = SkipAfterCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 1, reflex.instance_variable_get("@count")
+    assert_equal 1, reflex.instance_variable_get(:@count)
   end
 
   test "skip_around_reflex works" do
@@ -455,7 +455,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = SkipAroundCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 7, reflex.instance_variable_get("@count")
+    assert_equal 7, reflex.instance_variable_get(:@count)
   end
 
   test "skip_before_reflex works in inherited reflex" do
@@ -484,7 +484,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = InheritedSkipApplicationReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 6, reflex.instance_variable_get("@count")
+    assert_equal 6, reflex.instance_variable_get(:@count)
   end
 
   test "basic prepend_before_reflex works" do
@@ -509,7 +509,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = SimplePrependBeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 3, reflex.instance_variable_get("@count")
+    assert_equal 3, reflex.instance_variable_get(:@count)
   end
 
   test "prepend_before_reflex with block works" do
@@ -529,7 +529,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = BlockPrependBeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 3, reflex.instance_variable_get("@count")
+    assert_equal 3, reflex.instance_variable_get(:@count)
   end
 
   test "basic prepend_before_reflex works in inherited reflex" do
@@ -559,7 +559,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = InheritedPrependBeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 9, reflex.instance_variable_get("@count")
+    assert_equal 9, reflex.instance_variable_get(:@count)
   end
 
   test "basic prepend_around_reflex works" do
@@ -588,7 +588,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = SimplePrependAroundCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 26, reflex.instance_variable_get("@count")
+    assert_equal 26, reflex.instance_variable_get(:@count)
   end
 
   test "basic prepend_after_reflex works" do
@@ -613,7 +613,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = SimplePrependAfterCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 9, reflex.instance_variable_get("@count")
+    assert_equal 9, reflex.instance_variable_get(:@count)
   end
 
   test "append before_, around_ and after_reflex works" do
@@ -645,7 +645,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
 
     reflex = AppendCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
     reflex.process(:increment)
-    assert_equal 25, reflex.instance_variable_get("@count")
+    assert_equal 25, reflex.instance_variable_get(:@count)
   end
 end
 

--- a/test/concern_enhancer_test.rb
+++ b/test/concern_enhancer_test.rb
@@ -10,9 +10,6 @@ class StimulusReflex::ConcernTest < ActiveSupport::TestCase
 
   class TestReflex < StimulusReflex::Reflex
     include TestConcern
-
-    def initialize
-    end
   end
 
   class TestController < ActionController::Base


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement + Bug fix

## Description

Moved the code responsible for handling Action Cable connection status classes on the DOM `body` from main SR initializer function to the Action Cable transport module. Brought AC consumer deprecation warning into the transport as well.

Refactored Action Cable transport module to call on a new `connectionStatusClass` function, reducing code repetition.

Created event listeners for `turbolinks:load` and `turbo:load` to run `connectionStatusClass`.

Renamed `ActionCableTransport.set` to `ActionCableTransport.initialize`.

## Why should this be added

1. Separation of concerns and preparation for pluggable transport mechanisms in SR 4.
2. Fixes a bug where Turbo Drive would remove the body classes upon navigation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update