### PR TITLE
Extract StimulusReflex::Fragment

### DIFF
--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "uri"
 require "open-uri"
 require "rack"
@@ -15,6 +13,7 @@ require "stimulus_reflex/cable_ready_channels"
 require "stimulus_reflex/concern_enhancer"
 require "stimulus_reflex/configuration"
 require "stimulus_reflex/callbacks"
+require "stimulus_reflex/fragment"
 require "stimulus_reflex/request_parameters"
 require "stimulus_reflex/reflex"
 require "stimulus_reflex/reflex_data"

--- a/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
@@ -11,7 +11,7 @@ module StimulusReflex
       selectors = selectors.select { |s| fragment.match(s).present? }
       selectors.each do |selector|
         operations << [selector, :morph]
-        html = fragment.match(selector).inner_html(save_with: Broadcaster::DEFAULT_HTML_WITHOUT_FORMAT)
+        html = fragment.match(selector).to_html
         cable_ready.morph(
           selector: selector,
           html: html,

--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -13,7 +13,7 @@ module StimulusReflex
             operations << [update.selector, :morph]
             cable_ready.morph(
               selector: update.selector,
-              html: match.inner_html(save_with: Broadcaster::DEFAULT_HTML_WITHOUT_FORMAT),
+              html: match.to_html,
               payload: payload,
               children_only: true,
               permanent_attribute_name: permanent_attribute_name,

--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -7,8 +7,8 @@ module StimulusReflex
         selectors, html = morph
         updates = create_update_collection(selectors, html)
         updates.each do |update|
-          fragment = Nokogiri::HTML.fragment(update.html.to_s)
-          match = fragment.at_css(update.selector)
+          fragment = StimulusReflex::Fragment.new(update.html)
+          match = fragment.match(update.selector)
           if match.present?
             operations << [update.selector, :morph]
             cable_ready.morph(

--- a/lib/stimulus_reflex/fragment.rb
+++ b/lib/stimulus_reflex/fragment.rb
@@ -2,7 +2,7 @@
 
 module StimulusReflex
   class Fragment
-    delegate :to_html, to: :"@fragment"
+    delegate :to_html, to: :@fragment
 
     def initialize(html)
       @fragment = Nokogiri::HTML.fragment(html.to_s)

--- a/lib/stimulus_reflex/fragment.rb
+++ b/lib/stimulus_reflex/fragment.rb
@@ -7,7 +7,7 @@ module StimulusReflex
     def initialize(html)
       @fragment = Nokogiri::HTML.fragment(html.to_s)
       @matches = {
-        "body" => @fragment
+        "body" => Match.new(@fragment)
       }
     end
 
@@ -16,7 +16,15 @@ module StimulusReflex
     end
 
     def match(selector)
-      @matches[selector] ||= @fragment.at_css(selector)
+      @matches[selector] ||= Match.new(@fragment.at_css(selector))
+    end
+
+    Match = Struct.new(:element) do
+      delegate :present?, to: :element
+
+      def to_html
+        element&.inner_html(save_with: Broadcaster::DEFAULT_HTML_WITHOUT_FORMAT)
+      end
     end
   end
 end

--- a/lib/stimulus_reflex/fragment.rb
+++ b/lib/stimulus_reflex/fragment.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module StimulusReflex
+  class Fragment
+    delegate :to_html, to: :"@fragment"
+
+    def initialize(html)
+      @fragment = Nokogiri::HTML.fragment(html.to_s)
+      @matches = {
+        "body" => @fragment
+      }
+    end
+
+    def empty?
+      @fragment.content.empty?
+    end
+
+    def match(selector)
+      @matches[selector] ||= @fragment.at_css(selector)
+    end
+  end
+end


### PR DESCRIPTION
# Enhancement

## Description

In preparation of a few things I'd like to try out, I found that it'd make sense to create a `Fragment` wrapper around `Nokogiri::Fragment`. In addition to just wrapping, it provides simplified access to `Match`es

I think even more functionality could find its place here, but I wanted to keep it simple at first.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
