### PR TITLE
Extract CableReadyable

### DIFF
--- a/lib/stimulus_reflex/broadcasters/broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/broadcaster.rb
@@ -12,7 +12,7 @@ module StimulusReflex
       @reflex = reflex
       @logger = Rails.logger if defined?(Rails.logger)
       @operations = []
-      @cable_ready = StimulusReflex::CableReadyChannels.new(reflex.stream_name, reflex.reflex_id)
+      @cable_ready = StimulusReflex::CableReadyChannels.new(reflex)
     end
 
     def nothing?

--- a/lib/stimulus_reflex/broadcasters/broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/broadcaster.rb
@@ -2,8 +2,8 @@
 
 module StimulusReflex
   class Broadcaster
-    attr_reader :reflex, :logger, :operations
-    delegate :cable_ready, :permanent_attribute_name, :payload, to: :reflex
+    attr_reader :reflex, :cable_ready, :logger, :operations
+    delegate :permanent_attribute_name, :payload, to: :reflex
 
     DEFAULT_HTML_WITHOUT_FORMAT = Nokogiri::XML::Node::SaveOptions::DEFAULT_HTML &
       ~Nokogiri::XML::Node::SaveOptions::FORMAT
@@ -12,6 +12,7 @@ module StimulusReflex
       @reflex = reflex
       @logger = Rails.logger if defined?(Rails.logger)
       @operations = []
+      @cable_ready = StimulusReflex::CableReadyChannels.new(reflex.stream_name, reflex.reflex_id)
     end
 
     def nothing?

--- a/lib/stimulus_reflex/cable_readiness.rb
+++ b/lib/stimulus_reflex/cable_readiness.rb
@@ -3,7 +3,7 @@
 require "active_support/concern"
 
 module StimulusReflex
-  module CableReadyable
+  module CableReadiness
     extend ActiveSupport::Concern
 
     prepended do

--- a/lib/stimulus_reflex/cable_ready_channels.rb
+++ b/lib/stimulus_reflex/cable_ready_channels.rb
@@ -4,9 +4,9 @@ module StimulusReflex
   class CableReadyChannels
     delegate :[], to: "cable_ready_channels"
 
-    def initialize(stream_name, reflex_id)
-      @stream_name = stream_name
-      @reflex_id = reflex_id
+    def initialize(reflex)
+      @stream_name = reflex.stream_name
+      @reflex_id = reflex.reflex_id
     end
 
     def cable_ready_channels

--- a/lib/stimulus_reflex/cable_readyable.rb
+++ b/lib/stimulus_reflex/cable_readyable.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module StimulusReflex
+  module CableReadyable
+    extend ActiveSupport::Concern
+
+    prepended do
+      attr_reader :cable_ready
+    end
+
+    def initialize(*args, **kwargs)
+      super(*args, **kwargs)
+
+      if is_a? CableReady::Broadcaster
+        message = <<~MSG
+
+          #{self.class.name} includes CableReady::Broadcaster, and you need to remove it.
+          Reflexes have their own CableReady interface. You can just assume that it's present.
+          See https://docs.stimulusreflex.com/rtfm/cableready#using-cableready-inside-a-reflex-action for more details.
+
+        MSG
+        raise TypeError.new(message.strip)
+      end
+
+      @cable_ready = StimulusReflex::CableReadyChannels.new(stream_name, reflex_id)
+    end
+  end
+end

--- a/lib/stimulus_reflex/cable_readyable.rb
+++ b/lib/stimulus_reflex/cable_readyable.rb
@@ -24,7 +24,7 @@ module StimulusReflex
         raise TypeError.new(message.strip)
       end
 
-      @cable_ready = StimulusReflex::CableReadyChannels.new(stream_name, reflex_id)
+      @cable_ready = StimulusReflex::CableReadyChannels.new(self)
     end
   end
 end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "stimulus_reflex/cable_readyable"
+require "stimulus_reflex/cable_readiness"
 
 ClientAttributes = Struct.new(:reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, keyword_init: true)
 
 class StimulusReflex::Reflex
   class VersionMismatchError < StandardError; end
 
-  prepend StimulusReflex::CableReadyable
+  prepend StimulusReflex::CableReadiness
   include ActiveSupport::Rescuable
   include StimulusReflex::Callbacks
   include ActionView::Helpers::TagHelper

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -30,8 +30,8 @@ class StimulusReflex::Reflex
     @selectors = selectors
     @method_name = method_name
     @params = params
-    @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     @client_attributes = ClientAttributes.new(client_attributes)
+    @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     @logger = suppress_logging ? nil : StimulusReflex::Logger.new(self)
     @payload = {}
     @headers = {}

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
+require "stimulus_reflex/cable_readyable"
+
 ClientAttributes = Struct.new(:reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, keyword_init: true)
 
 class StimulusReflex::Reflex
   class VersionMismatchError < StandardError; end
 
+  prepend StimulusReflex::CableReadyable
   include ActiveSupport::Rescuable
   include StimulusReflex::Callbacks
   include ActionView::Helpers::TagHelper
   include CableReady::Identifiable
 
   attr_accessor :payload, :headers
-  attr_reader :cable_ready, :channel, :url, :element, :selectors, :method_name, :broadcaster, :client_attributes, :logger
+  attr_reader :channel, :url, :element, :selectors, :method_name, :broadcaster, :client_attributes, :logger
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
 
@@ -21,17 +24,6 @@ class StimulusReflex::Reflex
   delegate :reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, to: :client_attributes
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
-    if is_a? CableReady::Broadcaster
-      message = <<~MSG
-
-        #{self.class.name} includes CableReady::Broadcaster, and you need to remove it.
-        Reflexes have their own CableReady interface. You can just assume that it's present.
-        See https://docs.stimulusreflex.com/rtfm/cableready#using-cableready-inside-a-reflex-action for more details.
-
-      MSG
-      raise TypeError.new(message.strip)
-    end
-
     @channel = channel
     @url = url
     @element = element
@@ -41,7 +33,6 @@ class StimulusReflex::Reflex
     @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     @client_attributes = ClientAttributes.new(client_attributes)
     @logger = suppress_logging ? nil : StimulusReflex::Logger.new(self)
-    @cable_ready = StimulusReflex::CableReadyChannels.new(stream_name, reflex_id)
     @payload = {}
     @headers = {}
 


### PR DESCRIPTION
# Refactoring

## Description

Extracts a `CableReadyable` module to be prepended in the `Reflex` class (I'm open to better naming options 😅 )

## Why should this be added

This PR emanated from a pairing session with @hopsoft and the there perceived need to clean up the `Reflex` class a bit. This also serves further modularization. Observe that I've also given `Broadcaster` its own `StimulusReflex::CableReadyChannels` instance, so the `prepend StimulusReflex::CableReadyable` could become an optional add-on in v4.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
