### PR TITLE
Consolidate morph method

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -20,7 +20,6 @@ class StimulusReflex::Reflex
 
   delegate :connection, :stream_name, to: :channel
   delegate :controller_class, :flash, :session, to: :request
-  delegate :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
   delegate :reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, to: :client_attributes
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
@@ -83,6 +82,24 @@ class StimulusReflex::Reflex
     morph :page if broadcaster.nil?
 
     broadcaster.broadcast(*args)
+  end
+
+  def broadcast_halt(data:)
+    morph :page if broadcaster.nil?
+
+    broadcaster.broadcast_halt(data: data)
+  end
+
+  def broadcast_forbid(data:)
+    morph :page if broadcaster.nil?
+
+    broadcaster.broadcast_forbid(data: data)
+  end
+
+  def broadcast_error(data:, body:)
+    morph :page if broadcaster.nil?
+
+    broadcaster.broadcast_error(data: data, body: body)
   end
 
   def morph(selectors, html = nil)

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -20,7 +20,7 @@ class StimulusReflex::Reflex
 
   delegate :connection, :stream_name, to: :channel
   delegate :controller_class, :flash, :session, to: :request
-  delegate :broadcast, :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
+  delegate :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
   delegate :reflex_id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, to: :client_attributes
 
   def initialize(channel, url: nil, element: nil, selectors: [], method_name: nil, params: {}, client_attributes: {})
@@ -31,7 +31,6 @@ class StimulusReflex::Reflex
     @method_name = method_name
     @params = params
     @client_attributes = ClientAttributes.new(client_attributes)
-    @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     @logger = suppress_logging ? nil : StimulusReflex::Logger.new(self)
     @payload = {}
     @headers = {}
@@ -80,10 +79,17 @@ class StimulusReflex::Reflex
     end
   end
 
+  def broadcast(*args)
+    morph :page if broadcaster.nil?
+
+    broadcaster.broadcast(*args)
+  end
+
   def morph(selectors, html = nil)
     case selectors
     when :page
-      raise StandardError.new("Cannot call :page morph after :#{broadcaster.to_sym} morph") unless broadcaster.page?
+      raise StandardError.new("Cannot call :page morph after :#{broadcaster.to_sym} morph") if broadcaster&.selector? || broadcaster&.nothing?
+      @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     when :nothing
       raise StandardError.new("Cannot call :nothing morph after :selector morph") if broadcaster.selector?
       @broadcaster = StimulusReflex::NothingBroadcaster.new(self) unless broadcaster.nothing?


### PR DESCRIPTION
# Enhancement

## Description

Apply the same logic to `morph`, even if it's a page morph

## Why should this be added

Another small one from a family of upcoming patches (and inspired by a pairing session), this aims to consolidate the logic around page morphs a bit to the other morph types. There's more to come - I'd like to go full OO here, but this one should come first, and seems straightforward.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
