### PR TITLE
configure operations for morph and replace

### DIFF
--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -21,6 +21,11 @@ StimulusReflex.configure do |config|
 
   # config.on_missing_default_urls = :warn
 
+  # Override the CableReady operation used for morphing and replacing content
+
+  # config.morph_operation = :morph
+  # config.replace_operation = :inner_html
+
   # Override the parent class that the StimulusReflex ActionCable channel inherits from
 
   # config.parent_channel = "ApplicationCable::Channel"

--- a/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/page_broadcaster.rb
@@ -10,16 +10,16 @@ module StimulusReflex
 
       selectors = selectors.select { |s| fragment.match(s).present? }
       selectors.each do |selector|
-        operations << [selector, :morph]
+        operations << [selector, StimulusReflex.config.morph_operation]
         html = fragment.match(selector).to_html
-        cable_ready.morph(
+        cable_ready.send StimulusReflex.config.morph_operation, {
           selector: selector,
           html: html,
           payload: payload,
           children_only: true,
           permanent_attribute_name: permanent_attribute_name,
           stimulus_reflex: data.merge(morph: to_sym)
-        )
+        }
       end
       cable_ready.broadcast
     end

--- a/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
+++ b/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb
@@ -10,23 +10,23 @@ module StimulusReflex
           fragment = StimulusReflex::Fragment.new(update.html)
           match = fragment.match(update.selector)
           if match.present?
-            operations << [update.selector, :morph]
-            cable_ready.morph(
+            operations << [update.selector, StimulusReflex.config.morph_operation]
+            cable_ready.send StimulusReflex.config.morph_operation, {
               selector: update.selector,
               html: match.to_html,
               payload: payload,
               children_only: true,
               permanent_attribute_name: permanent_attribute_name,
               stimulus_reflex: data.merge(morph: to_sym)
-            )
+            }
           else
-            operations << [update.selector, :inner_html]
-            cable_ready.inner_html(
+            operations << [update.selector, StimulusReflex.config.replace_operation]
+            cable_ready.send StimulusReflex.config.replace_operation, {
               selector: update.selector,
               html: fragment.to_html,
               payload: payload,
               stimulus_reflex: data.merge(morph: to_sym)
-            )
+            }
           end
         end
       end

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -14,7 +14,7 @@ module StimulusReflex
   end
 
   class Configuration
-    attr_accessor :on_failed_sanity_checks, :on_new_version_available, :on_missing_default_urls, :parent_channel, :logging, :logger, :middleware
+    attr_accessor :on_failed_sanity_checks, :on_new_version_available, :on_missing_default_urls, :parent_channel, :logging, :logger, :middleware, :morph_operation, :replace_operation
 
     DEFAULT_LOGGING = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
@@ -26,6 +26,8 @@ module StimulusReflex
       @logging = DEFAULT_LOGGING
       @logger = Rails.logger
       @middleware = ActionDispatch::MiddlewareStack.new
+      @morph_operation = :morph
+      @replace_operation = :inner_html
     end
   end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Feature

## Description

Allow overriding the default CableReady operations used by page and selector morphs via the initializer. By default, these values are:
```ruby
config.morph_operation = :morph
config.replace_operation = :inner_html
```
The actual options passed to these operations is unchanged; it's up to the developer to implement a [custom CableReady operation](https://cableready.stimulusreflex.com/customization#custom-operations) that handles the data coming from the server.

If you are using this feature, be sure to be aware of the options being sent to the client by the [page](https://github.com/stimulusreflex/stimulus_reflex/blob/8d7f20f29d6fe4d9b92296d50bfb696622c5b0a5/lib/stimulus_reflex/broadcasters/page_broadcaster.rb#L15) broadcaster, as well as the selector broadcaster [morph](https://github.com/stimulusreflex/stimulus_reflex/blob/8d7f20f29d6fe4d9b92296d50bfb696622c5b0a5/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb#L14) and [replace](https://github.com/stimulusreflex/stimulus_reflex/blob/8d7f20f29d6fe4d9b92296d50bfb696622c5b0a5/lib/stimulus_reflex/broadcasters/selector_broadcaster.rb#L24) mechanisms.

For reference, here is the existing CableReady [morph](https://github.com/stimulusreflex/cable_ready/blob/3f016909de88639c70d5ba6efcacec6767147aa4/javascript/operations.js#L83) and [inner_html](https://github.com/stimulusreflex/cable_ready/blob/3f016909de88639c70d5ba6efcacec6767147aa4/javascript/operations.js#L47) operations, which could serve as a starting point.

## Why should this be added

1. People might want to use the [Alpine morph method](https://alpinejs.dev/plugins/morph).
2. People might want to clone the morph method but change it so that `children_only: false`. Note that this will likely interfere with normal SR operations, so consider it a sharp knife.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update