### PR TITLE
missing safe navigation

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -108,11 +108,11 @@ class StimulusReflex::Reflex
       raise StandardError.new("Cannot call :page morph after :#{broadcaster.to_sym} morph") if broadcaster&.selector? || broadcaster&.nothing?
       @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     when :nothing
-      raise StandardError.new("Cannot call :nothing morph after :selector morph") if broadcaster.selector?
-      @broadcaster = StimulusReflex::NothingBroadcaster.new(self) unless broadcaster.nothing?
+      raise StandardError.new("Cannot call :nothing morph after :selector morph") if broadcaster&.selector?
+      @broadcaster = StimulusReflex::NothingBroadcaster.new(self) unless broadcaster&.nothing?
     else
-      raise StandardError.new("Cannot call :selector morph after :nothing morph") if broadcaster.nothing?
-      @broadcaster = StimulusReflex::SelectorBroadcaster.new(self) unless broadcaster.selector?
+      raise StandardError.new("Cannot call :selector morph after :nothing morph") if broadcaster&.nothing?
+      @broadcaster = StimulusReflex::SelectorBroadcaster.new(self) unless broadcaster&.selector?
       broadcaster.append_morph(selectors, html)
     end
   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Selector and nothing morphs are currently broken because it's assumed that a `broadcaster` has been defined.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update