### PR TITLE
Call initial `setupDeclarativeReflexes()` on `document.readyState === 'complete'`

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -240,7 +240,7 @@ document.addEventListener('cable-ready:after-morph', afterDOMUpdate)
 window.addEventListener('load', setupDeclarativeReflexes)
 
 document.addEventListener('readystatechange', event => {
-  if (event.target.readyState === 'complete') {
+  if (document.readyState === 'complete') {
     setupDeclarativeReflexes()
   }
 })

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -237,9 +237,7 @@ document.addEventListener('cable-ready:before-inner-html', beforeDOMUpdate)
 document.addEventListener('cable-ready:before-morph', beforeDOMUpdate)
 document.addEventListener('cable-ready:after-inner-html', afterDOMUpdate)
 document.addEventListener('cable-ready:after-morph', afterDOMUpdate)
-window.addEventListener('load', setupDeclarativeReflexes)
-
-document.addEventListener('readystatechange', event => {
+document.addEventListener('readystatechange', () => {
   if (document.readyState === 'complete') {
     setupDeclarativeReflexes()
   }

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -239,4 +239,10 @@ document.addEventListener('cable-ready:after-inner-html', afterDOMUpdate)
 document.addEventListener('cable-ready:after-morph', afterDOMUpdate)
 window.addEventListener('load', setupDeclarativeReflexes)
 
-export { initialize, register, useReflex }
+document.addEventListener('readystatechange', event => {
+  if (event.target.readyState === 'complete') {
+    setupDeclarativeReflexes()
+  }
+})
+
+export { initialize, register, useReflex, setupDeclarativeReflexes }


### PR DESCRIPTION
## Type of PR

Bug Fix

## Description

This improves the reliability when using Importmaps, so that we can be sure that the DOM is setup properly, so the `setupDeclarativeReflexes()` function can be called in the right order.

Additionally we export the `setupDeclarativeReflexes()` so users can call this function manually if needed, i.e. if they have a specific load order/setup.

## Why should this be added

Improves the reliability when using StimulusReflex with Importmaps.

Thanks to @matheau for reporting this and providing their work-around.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
