### PR TITLE
Provide JavaScript package version on global `StimulusReflex` object

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -5,7 +5,10 @@ import * as StimulusReflex from './stimulus_reflex'
 import Debug from './debug'
 import Deprecate from './deprecate'
 
+import packageInfo from '../package.json'
+
 const global = {
+  version: packageInfo.version,
   ...StimulusReflex,
   get debug () {
     return Debug.value


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

Allows users to access the StimulusReflex JavaScript package version via `StimulusReflex.version`.

## Why should this be added

CableReady already does this today via `CableReady.version`. In order to match that behaviour we should also do it on the exported StimulusReflex object.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update