### PR TITLE
Make `version` import from `package.json` webpack 5 compatible

### DIFF
--- a/javascript/reflex_data.js
+++ b/javascript/reflex_data.js
@@ -5,7 +5,7 @@ import { getReflexRoots } from './reflexes'
 import { uuidv4 } from './utils'
 import { elementToXPath } from './utils'
 
-import { version } from '../package.json'
+import packageInfo from '../package.json'
 
 export default class ReflexData {
   constructor (
@@ -130,7 +130,7 @@ export default class ReflexData {
       args: this.args,
       url: this.url,
       tabId: this.tabId,
-      version
+      version: packageInfo.version
     }
   }
 }


### PR DESCRIPTION
# Type of PR

Bug fix

## Description

This PR changes how the `version` from `package.json` gets imported.

Analog to https://github.com/stimulusreflex/cable_ready/pull/169

## Why should this be added

Easy to fix, easy to support webpack 5

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
