### PR TITLE
`initialize` doesn't need to return a reference to `reflexes`

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -226,7 +226,7 @@ const register = (controller, options = {}) => {
 
   scanForReflexesOnElement(controller.element)
 
-  emitEvent('stimulus-reflex:registered', { detail: { controller } })
+  emitEvent('stimulus-reflex:controller-registered', { detail: { controller } })
 }
 
 const useReflex = (controller, options = {}) => {

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -21,7 +21,8 @@ import {
   serializeForm,
   elementInvalid,
   getReflexElement,
-  getReflexOptions
+  getReflexOptions,
+  emitEvent
 } from './utils'
 
 // Default StimulusReflexController that is implicitly wired up as data-controller for any DOM elements
@@ -70,7 +71,7 @@ const initialize = (
     childList: true,
     subtree: true
   })
-  return reflexes
+  emitEvent('stimulus-reflex:initialized')
 }
 
 // Registers a Stimulus controller and extends it with StimulusReflex behavior
@@ -224,6 +225,8 @@ const register = (controller, options = {}) => {
     })
 
   scanForReflexesOnElement(controller.element)
+
+  emitEvent('stimulus-reflex:registered', { detail: { controller } })
 }
 
 const useReflex = (controller, options = {}) => {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Enhancement

## Description

`initialize` no longer returns a reference to the `reflexes` collection.

Also, I added two new library events:
`stimulus-reflex:initialized`
`stimulus-reflex:registered`

The first one fires at the end of the `initialized` method, and has an empty `details` object, whereas the second one fires every time a Stimulus controller calls `StimulusReflex.register` and has a reference to the controller instance in the `details` object.

## Why should this be added

@marcoroth appealed to me to reconsider how the `reflexes` collection should best be made available. Previously, I was returning it from the `StimulusReflex.initialize` method, but the `StimulusReflex` class exposes it as well.

Given that the functionality I want is still easily available, it makes sense to exercise some restraint and keep the `initialize` function returning a void.

More library events are useful for future plugin functionality.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update