### PR TITLE
ReflexData must handle url parameters

### DIFF
--- a/lib/stimulus_reflex/reflex_data.rb
+++ b/lib/stimulus_reflex/reflex_data.rb
@@ -49,8 +49,16 @@ class StimulusReflex::ReflexData
     Rack::Utils.parse_nested_query(data["formData"])
   end
 
+  def params
+    form_params.merge(url_params)
+  end
+
   def form_params
     form_data.deep_merge(data["params"] || {})
+  end
+
+  def url_params
+    Rack::Utils.parse_nested_query(URI.parse(url).query)
   end
 
   def id

--- a/lib/stimulus_reflex/reflex_factory.rb
+++ b/lib/stimulus_reflex/reflex_factory.rb
@@ -9,7 +9,7 @@ class StimulusReflex::ReflexFactory
         element: reflex_data.element,
         selectors: reflex_data.selectors,
         method_name: reflex_data.method_name,
-        params: reflex_data.form_params,
+        params: reflex_data.params,
         client_attributes: {
           id: reflex_data.id,
           tab_id: reflex_data.tab_id,


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

`ReflexData` needs to intelligently merge both URL and form parameters, in order to correctly mimic Action Dispatch's parameter processing behaviour. URL parameters take priority over form parameters.

`ReflexFactory` now accesses a new `params` accessor when creating a Reflex.

Thanks to @afomera, @hopsoft, @KonnorRogers, @erlingur and @RolandStuder for their patience and assistance tracking this down.

## Why should this be added

URL parameters are currently ignored, which is bad.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update