### PR TITLE
introduce operations option for SR initialize

### DIFF
--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -22,6 +22,7 @@ StimulusReflex.configure do |config|
   # config.on_missing_default_urls = :warn
 
   # Override the CableReady operation used for morphing and replacing content
+  # If you change these, you'll need to pass an `operations` option when you initalize SR on the client
 
   # config.morph_operation = :morph
   # config.replace_operation = :inner_html


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix + enhancement

## Description

Introduces a new option to `StimulusReflex.initialize`, `operations`, which is used to override framework default CableReady operations for *morph* and *replace* tasks. The operations will default to `morph` and `inner_html` unless specified. Note that the default *morph* task is likely to become `morphdom` before SR 3.5 ships.

```js
StimulusReflex.initialize(application, {
  controller,
  isolate: true,
  operations: {morph: 'idiomorph'}
})
```

## Why should this be added

This should have been done with #599, which is currently broken. If the default operations are changed via the SR initializer, the Reflex is successfully created and executed on the server, but the event listeners were hard-coded to operate on `morph` and `innerHtml` operations. No client-side updates are possible in this scenario.

I will go back to update the README on the previous PR to reflect the need to pass an `operations` object when this PR is merged.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update