### PR TITLE
Handle Table-less TR and TD

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
@@ -204,6 +206,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-linux
 

--- a/lib/stimulus_reflex/html/document.rb
+++ b/lib/stimulus_reflex/html/document.rb
@@ -20,7 +20,7 @@ module StimulusReflex
       end
 
       def initialize(html)
-        @document = Nokogiri::HTML5::Document.parse(html.to_s)
+        @document = Nokogiri::HTML::Document.parse(html.to_s)
         @matches = {
           "body" => Match.new(@document.at_css("body"))
         }

--- a/test/html/document_test.rb
+++ b/test/html/document_test.rb
@@ -167,4 +167,16 @@ class StimulusReflex::HTML::DocumentTest < ActiveSupport::TestCase
     assert_equal outer_p, document.match("p").outer_html.squish
     assert_equal inner_p, document.match("p").inner_html.squish
   end
+
+  test "should properly handle a tr without the parent table" do
+    html = "<tr><td>1</td><td>2</td></tr>"
+    document = StimulusReflex::HTML::Document.new(html)
+    assert_equal html, document.to_html
+  end
+
+  test "should properly handle a td without the parent table or td" do
+    html = "<td>1</td>"
+    document = StimulusReflex::HTML::Document.new(html)
+    assert_equal html, document.to_html
+  end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug Fix

## Description

Nokogiri dismisses "invalid" HTML, but since we often need to parse incomplete HTML, this causes issues.

Fixes # (issue)

## Why should this be added

When trying to morph a `tr` element, `innerHTML` is replaced instead because the `tr` node is not found in the parsed document (because it gets discarded).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
