### PR TITLE
Update manifest file when `stimulus_reflex` generator used for repo's using bundlers other than importmaps

### DIFF
--- a/lib/generators/stimulus_reflex/stimulus_reflex_generator.rb
+++ b/lib/generators/stimulus_reflex/stimulus_reflex_generator.rb
@@ -41,6 +41,7 @@ class StimulusReflexGenerator < Rails::Generators::NamedBase
 
     template(reflex_src, reflex_path) unless options[:skip_reflex]
     template(stimulus_controller_src, stimulus_controller_path) unless options[:skip_stimulus]
+    rails_command "stimulus:manifest:update" unless Rails.root.join("config/importmap.rb").exist?
 
     if file_name == "example"
       controller_src = fetch("/app/controllers/examples_controller.rb.tt")


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
enhancement

## Description
Currently the `stimulus_reflex` generator does not update the ~~`app/javascript/controllers/index.js.bak`~~ `app/javascript/controllers/index.js` file which needs to get updated every time a new stimulus controller is generated _for other build systems expect `importmaps`_.

This PR runs the `stimulus:manifest:update` command to update the ~~`app/javascript/controllers/index.js.bak`~~  `app/javascript/controllers/index.js` file, when the `stimulus_reflex` generator is used.

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Why should this be added
It should be added because it saves users from running the `manifest:update` command after using the `stimulus_reflex` generator.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
