### PR TITLE
Use Util functions from CableReady

### DIFF
--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -1,6 +1,7 @@
 import Schema from './schema'
 import Deprecate from './deprecate'
 import Debug from './debug'
+import { Utils } from 'cable_ready'
 
 // uuid4 function taken from stackoverflow
 // https://stackoverflow.com/a/2117523/554903
@@ -55,32 +56,16 @@ const camelize = (value, uppercaseFirstLetter = true) => {
   return value
 }
 
-const debounce = (callback, delay = 250) => {
-  let timeoutId
-  return (...args) => {
-    clearTimeout(timeoutId)
-    timeoutId = setTimeout(() => {
-      timeoutId = null
-      callback(...args)
-    }, delay)
-  }
-}
+// TODO: remove this in v4 (potentially!)
+const XPathToElement = Utils.xpathToElement
+const XPathToArray = Utils.xpathToElementArray
+const debounce = Utils.debounce
+const emitEvent = (name, detail = {}) => Utils.dispatch(document, name, detail)
 
 const extractReflexName = reflexString => {
   const match = reflexString.match(/(?:.*->)?(.*?)(?:Reflex)?#/)
 
   return match ? match[1] : ''
-}
-
-const emitEvent = (event, detail) => {
-  document.dispatchEvent(
-    new CustomEvent(event, {
-      bubbles: true,
-      cancelable: false,
-      detail
-    })
-  )
-  if (window.jQuery) window.jQuery(document).trigger(event, detail)
 }
 
 // construct a valid xPath for an element in the DOM
@@ -106,35 +91,6 @@ const elementToXPath = element => {
       ix++
     }
   }
-}
-
-// TODO: remove this in v4 (potentially!)
-const XPathToElement = xpath => {
-  return document.evaluate(
-    xpath,
-    document,
-    null,
-    XPathResult.FIRST_ORDERED_NODE_TYPE,
-    null
-  ).singleNodeValue
-}
-
-const XPathToArray = (xpath, reverse = false) => {
-  const snapshotList = document.evaluate(
-    xpath,
-    document,
-    null,
-    XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
-    null
-  )
-
-  const snapshots = []
-
-  for (let i = 0; i < snapshotList.snapshotLength; i++) {
-    snapshots.push(snapshotList.snapshotItem(i))
-  }
-
-  return reverse ? snapshots.reverse() : snapshots
 }
 
 const elementInvalid = element => {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@hotwired/stimulus": ">= 3.0",
     "@rails/actioncable": ">= 6.0",
-    "cable_ready": ">= 5.0.0-pre9"
+    "cable_ready": "https://github.com/cableready/dev-builds/archive/cable_ready/bb6a2d7.tar.gz"
   },
   "devDependencies": {
     "@open-wc/testing": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,10 +991,9 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-"cable_ready@>= 5.0.0-pre9":
+"cable_ready@https://github.com/cableready/dev-builds/archive/cable_ready/bb6a2d7.tar.gz":
   version "5.0.0-pre9"
-  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.0-pre9.tgz#9c082b796f7b7add7965ce637a8d8717726be5ab"
-  integrity sha512-m7XggG+LRPFLsbH78G603F3AAYpkv+VfGCouN6RrP20Mgz9H0+xr7v2DN2F1CeJBBAliYPKcAt/48uTGjSrBaA==
+  resolved "https://github.com/cableready/dev-builds/archive/cable_ready/bb6a2d7.tar.gz#59b1625cad7a00cf72a01f934d1af2f265a4ec0e"
   dependencies:
     morphdom "^2.6.1"
 


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

Use `XPathToElement`, `XPathToArray`, `debounce` and `dispatch` from CableReady. Enabled via https://github.com/stimulusreflex/cable_ready/pull/236

Resolves #571 

## Why should this be added

Less code and code sharing is always good.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

