### PR TITLE
Make Schema configurable

### DIFF
--- a/javascript/schema.js
+++ b/javascript/schema.js
@@ -21,13 +21,12 @@ export default {
     for (const attribute in schema) {
       const attributeName = attribute.slice(0, -9)
 
-      if (!this.hasOwnProperty(attributeName)) {
-        Object.defineProperty(this, attributeName, {
-          get: () => {
-            return schema[attribute]
-          }
-        })
-      }
+      Object.defineProperty(this, attributeName, {
+        get: () => {
+          return schema[attribute]
+        },
+        configurable: true
+      })
     }
   }
 }

--- a/javascript/test/schema.test.js
+++ b/javascript/test/schema.test.js
@@ -43,37 +43,61 @@ describe('Schema', () => {
     assert.equal(Schema.reflexDatasetAll, 'data-reflex-dataset-all')
     assert.equal(Schema.reflexSerializeForm, 'data-reflex-serialize-form')
     assert.equal(Schema.reflexFormSelector, 'data-reflex-form-selector')
-    assert.equal(Schema.reflexIncludeInnerHtml, 'data-reflex-include-inner-html')
-    assert.equal(Schema.reflexIncludeTextContent, 'data-reflex-include-text-content')
+    assert.equal(
+      Schema.reflexIncludeInnerHtml,
+      'data-reflex-include-inner-html'
+    )
+    assert.equal(
+      Schema.reflexIncludeTextContent,
+      'data-reflex-include-text-content'
+    )
   })
 
-  it("should override schema", () => {
+  it('should override schema', () => {
     Schema.set({ schema: schemaOne })
 
     assert.equal(Schema.reflex, 'data-reflex-one')
     assert.equal(Schema.reflexPermanent, 'data-reflex-permanent-one')
     assert.equal(Schema.reflexRoot, 'data-reflex-root-one')
-    assert.equal(Schema.reflexSuppressLogging, 'data-reflex-suppress-logging-one')
+    assert.equal(
+      Schema.reflexSuppressLogging,
+      'data-reflex-suppress-logging-one'
+    )
     assert.equal(Schema.reflexDataset, 'data-reflex-dataset-one')
     assert.equal(Schema.reflexDatasetAll, 'data-reflex-dataset-all-one')
     assert.equal(Schema.reflexSerializeForm, 'data-reflex-serialize-form-one')
     assert.equal(Schema.reflexFormSelector, 'data-reflex-form-selector-one')
-    assert.equal(Schema.reflexIncludeInnerHtml, 'data-reflex-include-inner-html-one')
-    assert.equal(Schema.reflexIncludeTextContent, 'data-reflex-include-text-content-one')
+    assert.equal(
+      Schema.reflexIncludeInnerHtml,
+      'data-reflex-include-inner-html-one'
+    )
+    assert.equal(
+      Schema.reflexIncludeTextContent,
+      'data-reflex-include-text-content-one'
+    )
   })
 
-  it("should override schema multipe times", () => {
+  it('should override schema multipe times', () => {
     Schema.set({ schema: schemaTwo })
 
     assert.equal(Schema.reflex, 'data-reflex-two')
     assert.equal(Schema.reflexPermanent, 'data-reflex-permanent-two')
     assert.equal(Schema.reflexRoot, 'data-reflex-root-two')
-    assert.equal(Schema.reflexSuppressLogging, 'data-reflex-suppress-logging-two')
+    assert.equal(
+      Schema.reflexSuppressLogging,
+      'data-reflex-suppress-logging-two'
+    )
     assert.equal(Schema.reflexDataset, 'data-reflex-dataset-two')
     assert.equal(Schema.reflexDatasetAll, 'data-reflex-dataset-all-two')
     assert.equal(Schema.reflexSerializeForm, 'data-reflex-serialize-form-two')
     assert.equal(Schema.reflexFormSelector, 'data-reflex-form-selector-two')
-    assert.equal(Schema.reflexIncludeInnerHtml, 'data-reflex-include-inner-html-two')
-    assert.equal(Schema.reflexIncludeTextContent, 'data-reflex-include-text-content-two')
+    assert.equal(
+      Schema.reflexIncludeInnerHtml,
+      'data-reflex-include-inner-html-two'
+    )
+    assert.equal(
+      Schema.reflexIncludeTextContent,
+      'data-reflex-include-text-content-two'
+    )
   })
 })

--- a/javascript/test/schema.test.js
+++ b/javascript/test/schema.test.js
@@ -1,0 +1,79 @@
+import { fixture, html, expect, assert } from '@open-wc/testing'
+
+import ReflexData from '../reflex_data'
+import Schema, { defaultSchema } from '../schema'
+
+const schemaOne = {
+  reflexAttribute: 'data-reflex-one',
+  reflexPermanentAttribute: 'data-reflex-permanent-one',
+  reflexRootAttribute: 'data-reflex-root-one',
+  reflexSuppressLoggingAttribute: 'data-reflex-suppress-logging-one',
+  reflexDatasetAttribute: 'data-reflex-dataset-one',
+  reflexDatasetAllAttribute: 'data-reflex-dataset-all-one',
+  reflexSerializeFormAttribute: 'data-reflex-serialize-form-one',
+  reflexFormSelectorAttribute: 'data-reflex-form-selector-one',
+  reflexIncludeInnerHtmlAttribute: 'data-reflex-include-inner-html-one',
+  reflexIncludeTextContentAttribute: 'data-reflex-include-text-content-one'
+}
+
+const schemaTwo = {
+  reflexAttribute: 'data-reflex-two',
+  reflexPermanentAttribute: 'data-reflex-permanent-two',
+  reflexRootAttribute: 'data-reflex-root-two',
+  reflexSuppressLoggingAttribute: 'data-reflex-suppress-logging-two',
+  reflexDatasetAttribute: 'data-reflex-dataset-two',
+  reflexDatasetAllAttribute: 'data-reflex-dataset-all-two',
+  reflexSerializeFormAttribute: 'data-reflex-serialize-form-two',
+  reflexFormSelectorAttribute: 'data-reflex-form-selector-two',
+  reflexIncludeInnerHtmlAttribute: 'data-reflex-include-inner-html-two',
+  reflexIncludeTextContentAttribute: 'data-reflex-include-text-content-two'
+}
+
+describe('Schema', () => {
+  beforeEach(() => {
+    Schema.set(defaultSchema)
+  })
+
+  it('should read from default schema', () => {
+    assert.equal(Schema.reflex, 'data-reflex')
+    assert.equal(Schema.reflexPermanent, 'data-reflex-permanent')
+    assert.equal(Schema.reflexRoot, 'data-reflex-root')
+    assert.equal(Schema.reflexSuppressLogging, 'data-reflex-suppress-logging')
+    assert.equal(Schema.reflexDataset, 'data-reflex-dataset')
+    assert.equal(Schema.reflexDatasetAll, 'data-reflex-dataset-all')
+    assert.equal(Schema.reflexSerializeForm, 'data-reflex-serialize-form')
+    assert.equal(Schema.reflexFormSelector, 'data-reflex-form-selector')
+    assert.equal(Schema.reflexIncludeInnerHtml, 'data-reflex-include-inner-html')
+    assert.equal(Schema.reflexIncludeTextContent, 'data-reflex-include-text-content')
+  })
+
+  it("should override schema", () => {
+    Schema.set({ schema: schemaOne })
+
+    assert.equal(Schema.reflex, 'data-reflex-one')
+    assert.equal(Schema.reflexPermanent, 'data-reflex-permanent-one')
+    assert.equal(Schema.reflexRoot, 'data-reflex-root-one')
+    assert.equal(Schema.reflexSuppressLogging, 'data-reflex-suppress-logging-one')
+    assert.equal(Schema.reflexDataset, 'data-reflex-dataset-one')
+    assert.equal(Schema.reflexDatasetAll, 'data-reflex-dataset-all-one')
+    assert.equal(Schema.reflexSerializeForm, 'data-reflex-serialize-form-one')
+    assert.equal(Schema.reflexFormSelector, 'data-reflex-form-selector-one')
+    assert.equal(Schema.reflexIncludeInnerHtml, 'data-reflex-include-inner-html-one')
+    assert.equal(Schema.reflexIncludeTextContent, 'data-reflex-include-text-content-one')
+  })
+
+  it("should override schema multipe times", () => {
+    Schema.set({ schema: schemaTwo })
+
+    assert.equal(Schema.reflex, 'data-reflex-two')
+    assert.equal(Schema.reflexPermanent, 'data-reflex-permanent-two')
+    assert.equal(Schema.reflexRoot, 'data-reflex-root-two')
+    assert.equal(Schema.reflexSuppressLogging, 'data-reflex-suppress-logging-two')
+    assert.equal(Schema.reflexDataset, 'data-reflex-dataset-two')
+    assert.equal(Schema.reflexDatasetAll, 'data-reflex-dataset-all-two')
+    assert.equal(Schema.reflexSerializeForm, 'data-reflex-serialize-form-two')
+    assert.equal(Schema.reflexFormSelector, 'data-reflex-form-selector-two')
+    assert.equal(Schema.reflexIncludeInnerHtml, 'data-reflex-include-inner-html-two')
+    assert.equal(Schema.reflexIncludeTextContent, 'data-reflex-include-text-content-two')
+  })
+})


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

This Pull Request enables the StimulusReflex schema to be overridden multiple times. Previously, setting `Schema.set(application)` more than once wouldn't save the new values.

Resolves #607 

## Why should this be added

This makes the behavior of `Schema.set(application)` consistent and lets the developer adjust it multiples times. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update