### PR TITLE
Emit `stimulus-reflex:ready` event on element instead of document

### DIFF
--- a/javascript/scanner.js
+++ b/javascript/scanner.js
@@ -2,7 +2,7 @@ import { reflexes } from './reflexes'
 import Schema from './schema'
 import { attributeValues, attributeValue } from './attributes'
 import { findControllerByReflexName, allReflexControllers } from './controllers'
-import { debounce, emitEvent } from './utils'
+import { debounce, dispatch } from './utils'
 
 // Sets up declarative reflex behavior.
 // Any elements that define data-reflex will automatically be wired up with the default StimulusReflexController.
@@ -10,7 +10,6 @@ import { debounce, emitEvent } from './utils'
 const scanForReflexes = debounce(() => {
   const reflexElements = document.querySelectorAll(`[${Schema.reflex}]`)
   reflexElements.forEach(element => scanForReflexesOnElement(element))
-  emitEvent('stimulus-reflex:ready')
 }, 20)
 
 const scanForReflexesOnElement = element => {
@@ -41,15 +40,28 @@ const scanForReflexesOnElement = element => {
   const controllerValue = attributeValue(controllers)
   const actionValue = attributeValue(actions)
 
+  let emitReadyEvent = false
+
   if (
     controllerValue &&
     element.getAttribute(Schema.controller) != controllerValue
   ) {
     element.setAttribute(Schema.controller, controllerValue)
+    emitReadyEvent = true
   }
 
   if (actionValue && element.getAttribute(Schema.action) != actionValue) {
     element.setAttribute(Schema.action, actionValue)
+    emitReadyEvent = true
+  }
+
+  if (emitReadyEvent) {
+    dispatch(element, 'stimulus-reflex:ready', {
+      reflex: reflexAttribute,
+      controller: controllerValue,
+      action: actionValue,
+      element
+    })
   }
 }
 export { scanForReflexes, scanForReflexesOnElement }

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -2,6 +2,7 @@ import Schema from './schema'
 import Deprecate from './deprecate'
 import Debug from './debug'
 import { Utils } from 'cable_ready'
+const { debounce, dispatch, xpathToElement, xpathToElementArray } = Utils
 
 // uuid4 function taken from stackoverflow
 // https://stackoverflow.com/a/2117523/554903
@@ -57,10 +58,9 @@ const camelize = (value, uppercaseFirstLetter = true) => {
 }
 
 // TODO: remove this in v4 (potentially!)
-const XPathToElement = Utils.xpathToElement
-const XPathToArray = Utils.xpathToElementArray
-const debounce = Utils.debounce
-const emitEvent = (name, detail = {}) => Utils.dispatch(document, name, detail)
+const XPathToElement = xpathToElement
+const XPathToArray = xpathToElementArray
+const emitEvent = (name, detail = {}) => dispatch(document, name, detail)
 
 const extractReflexName = reflexString => {
   const match = reflexString.match(/(?:.*->)?(.*?)(?:Reflex)?#/)
@@ -172,6 +172,7 @@ export {
   serializeForm,
   camelize,
   debounce,
+  dispatch,
   extractReflexName,
   emitEvent,
   elementToXPath,


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

Previously the `stimulus-reflex:ready` was invoked every time the `scanForReflexes()` function was called. With the recent changes of being able to load Stimulus controllers async we can't guarantee that the `stimulus-reflex:ready` was always triggered at the right moment in time and it wasn't guaranteed that all controllers were actually loaded and registered.

Since we can't guarantee that the "whole document and all controllers are loaded and ready", we instead emit an event on the actual element that we know that it is ready and was setup  for sure.

Resolves #608 

## Why should this be added

Consistently and better support for asynchronous loading of Stimulus controllers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
