### PR TITLE
Add `precompile_assets` option to disable assets compilation

### DIFF
--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -21,6 +21,11 @@ StimulusReflex.configure do |config|
 
   # config.on_missing_default_urls = :warn
 
+  # Enable/disable assets compilation
+  # `true` or `false`
+
+  # config.precompile_assets = true
+
   # Override the CableReady operation used for morphing and replacing content
 
   # config.morph_operation = :morph

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -14,7 +14,7 @@ module StimulusReflex
   end
 
   class Configuration
-    attr_accessor :on_failed_sanity_checks, :on_new_version_available, :on_missing_default_urls, :parent_channel, :logging, :logger, :middleware, :morph_operation, :replace_operation
+    attr_accessor :on_failed_sanity_checks, :on_new_version_available, :on_missing_default_urls, :parent_channel, :logging, :logger, :middleware, :morph_operation, :replace_operation, :precompile_assets
 
     DEFAULT_LOGGING = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
@@ -28,6 +28,7 @@ module StimulusReflex
       @middleware = ActionDispatch::MiddlewareStack.new
       @morph_operation = :morph
       @replace_operation = :inner_html
+      @precompile_assets = true
     end
   end
 end

--- a/lib/stimulus_reflex/engine.rb
+++ b/lib/stimulus_reflex/engine.rb
@@ -6,16 +6,25 @@ module StimulusReflex
       SanityChecker.check! unless Rails.env.production?
     end
 
+    # If you don't want to precompile StimulusReflex's assets (eg. because you're using webpack),
+    # you can do this in an initializer:
+    #
+    # config.after_initialize do
+    #   config.assets.precompile -= StimulusReflex::Engine::PRECOMPILE_ASSETS
+    # end
+    #
+    PRECOMPILE_ASSETS = %w[
+      stimulus_reflex.js
+      stimulus_reflex.min.js
+      stimulus_reflex.min.js.map
+      stimulus_reflex.umd.js
+      stimulus_reflex.umd.min.js
+      stimulus_reflex.umd.min.js.map
+    ]
+
     initializer "stimulus_reflex.assets" do |app|
-      if app.config.respond_to?(:assets)
-        app.config.assets.precompile += %w[
-          stimulus_reflex.js
-          stimulus_reflex.min.js
-          stimulus_reflex.min.js.map
-          stimulus_reflex.umd.js
-          stimulus_reflex.umd.min.js
-          stimulus_reflex.umd.min.js.map
-        ]
+      if app.config.respond_to?(:assets) && StimulusReflex.config.precompile_assets
+        app.config.assets.precompile += PRECOMPILE_ASSETS
       end
     end
 


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

This pull request ports over the changes introduced in https://github.com/stimulusreflex/cable_ready/pull/244

This allows developers to disable the assets pre-compilation step, which previously happened automatically if the gem was included and sprockets was installed in the app.

If the project is using esbuild/webpack/vite it's very likely that there's no need to precompile the StimulusReflex assets in your app.

## Why should this be added

So that developers can turn off the pre-compilation step if they don't ship the StimulusReflex assets via the Asset pipeline.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
