### PR TITLE
Add tests for `StimulusReflex::Configuration`

### DIFF
--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -8,36 +8,36 @@
 StimulusReflex.configure do |config|
   # Enable/disable exiting / warning when the sanity checks fail options:
   # `:exit` or `:warn` or `:ignore`
-
+  #
   # config.on_failed_sanity_checks = :exit
 
   # Enable/disable exiting / warning when there's a new StimulusReflex release
   # `:exit` or `:warn` or `:ignore`
-
+  #
   # config.on_new_version_available = :ignore
 
   # Enable/disable exiting / warning when there is no default URLs specified in environment config
   # `:warn` or `:ignore`
-
+  #
   # config.on_missing_default_urls = :warn
 
   # Enable/disable assets compilation
   # `true` or `false`
-
+  #
   # config.precompile_assets = true
 
   # Override the CableReady operation used for morphing and replacing content
-
+  #
   # config.morph_operation = :morph
   # config.replace_operation = :inner_html
 
   # Override the parent class that the StimulusReflex ActionCable channel inherits from
-
+  #
   # config.parent_channel = "ApplicationCable::Channel"
 
   # Override the logger that the StimulusReflex uses; default is Rails' logger
   # eg. Logger.new(RAILS_ROOT + "/log/reflex.log")
-
+  #
   # config.logger = Rails.logger
 
   # Customize server-side Reflex logging format, with optional colorization:
@@ -46,14 +46,14 @@ StimulusReflex.configure do |config|
   # You can also use attributes from your ActionCable Connection's identifiers that resolve to valid ActiveRecord models
   # eg. if your connection is `identified_by :current_user` and your User model has an email attribute, you can access r.email (it will display `-` if the user isn't logged in)
   # Learn more at: https://docs.stimulusreflex.com/appendices/troubleshooting#stimulusreflex-logging
-
+  #
   # config.logging = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
   # Optimized for speed, StimulusReflex doesn't enable Rack middleware by default.
   # If you are using Page Morphs and your app uses Rack middleware to rewrite part of the request path, you must enable those middleware modules in StimulusReflex.
   #
   # Learn more about registering Rack middleware in Rails here: https://guides.rubyonrails.org/rails_on_rack.html#configuring-middleware-stack
-
+  #
   # config.middleware.use FirstRackMiddleware
   # config.middleware.use SecondRackMiddleware
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+def revert_config_changes(key)
+  previous_value = StimulusReflex.config.send(key)
+
+  yield
+
+  StimulusReflex.config.send("#{key}=", previous_value)
+end
+
+class MyLogger
+end
+
+class MyRackMiddleWare
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env)
+
+    [status, headers, response]
+  end
+end
+
+class StimulusReflex::ConfigurationTest < ActionView::TestCase
+  test "sets on_failed_sanity_checks" do
+    revert_config_changes(:on_failed_sanity_checks) do
+      assert_equal :exit, StimulusReflex.config.on_failed_sanity_checks
+
+      StimulusReflex.configure do |config|
+        config.on_failed_sanity_checks = :warn
+      end
+
+      assert_equal :warn, StimulusReflex.config.on_failed_sanity_checks
+    end
+  end
+
+  test "sets on_new_version_available" do
+    revert_config_changes(:on_new_version_available) do
+      assert_equal :ignore, StimulusReflex.config.on_new_version_available
+
+      StimulusReflex.configure do |config|
+        config.on_new_version_available = :warn
+      end
+
+      assert_equal :warn, StimulusReflex.config.on_new_version_available
+    end
+  end
+
+  test "sets on_missing_default_urls" do
+    revert_config_changes(:on_missing_default_urls) do
+      assert_equal :warn, StimulusReflex.config.on_missing_default_urls
+
+      StimulusReflex.configure do |config|
+        config.on_missing_default_urls = :ignore
+      end
+
+      assert_equal :ignore, StimulusReflex.config.on_missing_default_urls
+    end
+  end
+
+  test "sets precompile_assets" do
+    revert_config_changes(:precompile_assets) do
+      assert StimulusReflex.config.precompile_assets
+
+      StimulusReflex.configure do |config|
+        config.precompile_assets = false
+      end
+
+      refute StimulusReflex.config.precompile_assets
+    end
+  end
+
+  test "sets morph_operation" do
+    revert_config_changes(:morph_operation) do
+      assert_equal :morph, StimulusReflex.config.morph_operation
+
+      StimulusReflex.configure do |config|
+        config.morph_operation = :inner_html
+      end
+
+      assert_equal :inner_html, StimulusReflex.config.morph_operation
+    end
+  end
+
+  test "sets replace_operation" do
+    revert_config_changes(:replace_operation) do
+      assert_equal :inner_html, StimulusReflex.config.replace_operation
+
+      StimulusReflex.configure do |config|
+        config.replace_operation = :morph
+      end
+
+      assert_equal :morph, StimulusReflex.config.replace_operation
+    end
+  end
+
+  test "sets parent_channel" do
+    revert_config_changes(:parent_channel) do
+      assert_equal "ActionCable::Channel::Base", StimulusReflex.config.parent_channel
+
+      StimulusReflex.configure do |config|
+        config.parent_channel = "ApplicationCable::Channel"
+      end
+
+      assert_equal "ApplicationCable::Channel", StimulusReflex.config.parent_channel
+    end
+  end
+
+  test "sets logger" do
+    revert_config_changes(:logger) do
+      assert_nil StimulusReflex.config.logger
+
+      logger = MyLogger.new
+
+      StimulusReflex.configure do |config|
+        config.logger = logger
+      end
+
+      assert_equal logger, StimulusReflex.config.logger
+    end
+  end
+
+  test "sets logging" do
+    revert_config_changes(:logging) do
+      logging = proc { "Custom Logger: #{session_id}" }
+
+      refute_equal logging, StimulusReflex.config.logging
+
+      StimulusReflex.configure do |config|
+        config.logging = logging
+      end
+
+      assert_equal logging, StimulusReflex.config.logging
+    end
+  end
+
+  test "uses middleware" do
+    assert_empty StimulusReflex.config.middleware.middlewares
+
+    StimulusReflex.configure do |config|
+      config.middleware.use MyRackMiddleWare
+    end
+
+    assert_includes StimulusReflex.config.middleware.middlewares, MyRackMiddleWare
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,9 @@ class TestController < ApplicationController
 end
 
 class SessionMock
+  def enabled?
+  end
+
   def load!
     nil
   end


### PR DESCRIPTION
# Type of PR

Tests

## Description

Similar to https://github.com/stimulusreflex/cable_ready/pull/254

Adds test coverage for the `CableReady::Config` class

## Why should this be added

Increasing the test coverage is always good.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
