### PR TITLE
Don't add `data-controller` to reflex element if parent already holds instance

### DIFF
--- a/javascript/controllers.js
+++ b/javascript/controllers.js
@@ -7,16 +7,14 @@ import { extractReflexName, reflexNameToControllerIdentifier } from './utils'
 // Returns StimulusReflex controllers local to the passed element based on the data-controller attribute.
 //
 const localReflexControllers = element => {
-  return attributeValues(element.getAttribute(Schema.controller)).reduce(
-    (memo, name) => {
-      const controller = App.app.getControllerForElementAndIdentifier(
-        element,
-        name
-      )
-      if (controller && controller.StimulusReflex) memo.push(controller)
-      return memo
-    },
-    []
+  const potentialIdentifiers = attributeValues(element.getAttribute(Schema.controller))
+
+  const potentialControllers = potentialIdentifiers.map(
+    identifier => App.app.getControllerForElementAndIdentifier(element, identifier)
+  )
+
+  return potentialControllers.filter(
+    controller => controller && controller.StimulusReflex
   )
 }
 
@@ -38,9 +36,11 @@ const allReflexControllers = element => {
 // it would select the 'test' controller.
 const findControllerByReflexName = (reflexName, controllers) => {
   const controller = controllers.find(controller => {
-    if (!controller.identifier) return
+    if (!controller || !controller.identifier) return
 
-    return controller.identifier === reflexNameToControllerIdentifier(extractReflexName(reflexName))
+    const identifier = reflexNameToControllerIdentifier(extractReflexName(reflexName))
+
+    return identifier === controller.identifier
   })
 
   return controller || controllers[0]

--- a/javascript/controllers.js
+++ b/javascript/controllers.js
@@ -2,7 +2,7 @@ import App from './app'
 import Schema from './schema'
 
 import { attributeValues } from './attributes'
-import { extractReflexName } from './utils'
+import { extractReflexName, reflexNameToControllerIdentifier } from './utils'
 
 // Returns StimulusReflex controllers local to the passed element based on the data-controller attribute.
 //
@@ -40,12 +40,7 @@ const findControllerByReflexName = (reflexName, controllers) => {
   const controller = controllers.find(controller => {
     if (!controller.identifier) return
 
-    return (
-      extractReflexName(reflexName)
-        .replace(/([a-z0–9])([A-Z])/g, '$1-$2')
-        .replace(/(::)/g, '--')
-        .toLowerCase() === controller.identifier
-    )
+    return controller.identifier === reflexNameToControllerIdentifier(extractReflexName(reflexName))
   })
 
   return controller || controllers[0]

--- a/javascript/scanner.js
+++ b/javascript/scanner.js
@@ -35,7 +35,12 @@ const scanForReflexesOnElement = element => {
       : 'stimulus-reflex'
 
     actions.push(`${reflexName.split('->')[0]}->${controllerName}#__perform`)
-    controllers.push(controllerName)
+
+    const parentControllerElement = element.closest(`[data-controller~=${controllerName}]`)
+
+    if (!parentControllerElement) {
+      controllers.push(controllerName)
+    }
   })
 
   const controllerValue = attributeValue(controllers)

--- a/javascript/scanner.js
+++ b/javascript/scanner.js
@@ -13,9 +13,11 @@ const scanForReflexes = debounce(() => {
   reflexElements.forEach(element => scanForReflexesOnElement(element))
 }, 20)
 
-const scanForReflexesOnElement = element => {
+const scanForReflexesOnElement = (element, controller = null) => {
   const controllerAttribute = element.getAttribute(Schema.controller)
-  const controllers = attributeValues(controllerAttribute)
+  const controllers = attributeValues(controllerAttribute).filter(
+    controller => controller !== 'stimulus-reflex'
+  )
 
   const reflexAttribute = element.getAttribute(Schema.reflex)
   const reflexAttributeNames = attributeValues(reflexAttribute)
@@ -26,9 +28,11 @@ const scanForReflexesOnElement = element => {
   )
 
   reflexAttributeNames.forEach(reflexName => {
-    const controller = findControllerByReflexName(
+    const potentialControllers = [controller].concat(allReflexControllers(element))
+
+    controller = findControllerByReflexName(
       reflexName,
-      allReflexControllers(element)
+      potentialControllers
     )
     const controllerName = controller
       ? controller.identifier

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -226,7 +226,7 @@ const register = (controller, options = {}) => {
       }
     })
 
-  scanForReflexesOnElement(controller.element)
+  scanForReflexesOnElement(controller.element, controller)
 
   emitEvent('stimulus-reflex:controller-registered', { detail: { controller } })
 }

--- a/javascript/test/controllers.extractReflexName.test.js
+++ b/javascript/test/controllers.extractReflexName.test.js
@@ -55,4 +55,18 @@ describe('findControllerByReflexName', () => {
       controller
     )
   })
+
+  it('returns dasherized controller', () => {
+    const controller = { identifier: 'some-thing' }
+    const controllers = [
+      { identifier: 'first' },
+      controller,
+      { identifier: 'last' }
+    ]
+
+    assert.equal(
+      findControllerByReflexName('click->SomeThingReflex#create', controllers),
+      controller
+    )
+  })
 })

--- a/javascript/test/dummy/regular_controller.js
+++ b/javascript/test/dummy/regular_controller.js
@@ -1,0 +1,5 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  connect () { }
+}

--- a/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
+++ b/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
@@ -170,7 +170,7 @@ describe('scanForReflexesOnElement', () => {
     assert.equal(button.dataset.controller, 'example2')
   })
 
-  it('should', async () => {
+  it('should not add data-controller to reflex element if parent holds', async () => {
     App.app.register('example', ExampleController)
 
     const controllerElement = await fixture(html`

--- a/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
+++ b/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
@@ -8,17 +8,17 @@ import { initialize } from '../stimulus_reflex'
 import App from '../app'
 import { scanForReflexesOnElement } from '../scanner'
 
+function registeredControllers () {
+  return Array.from(App.app.router.modulesByIdentifier.keys())
+}
+
 describe('scanForReflexesOnElement', () => {
   beforeEach(() => {
     initialize(application)
   })
 
   afterEach(() => {
-    const registeredControllers = Array.from(
-      App.app.router.modulesByIdentifier.keys()
-    )
-
-    App.app.unload(registeredControllers)
+    App.app.unload(registeredControllers())
   })
 
   it('should add the right action and controller attribute', async () => {
@@ -105,5 +105,149 @@ describe('scanForReflexesOnElement', () => {
     )
     assert.equal(element.dataset.action, 'click->stimulus-reflex#__perform')
     assert.equal(element.dataset.controller, 'stimulus-reflex')
+  })
+
+  it('should not add an additional data-controller attribute to the reflex element if any parent element already holds a controller instance', async () => {
+    App.app.register('example', ExampleController)
+
+    const controllerElement = await fixture(html`
+      <div data-controller="example">
+        <a data-reflex="click->Example#click">Click</a>
+      </div>
+    `)
+
+    const button = controllerElement.children[0]
+
+    scanForReflexesOnElement(button)
+
+    assert.equal(controllerElement.dataset.controller, 'example')
+
+    assert.equal(button.dataset.reflex, 'click->Example#click')
+    assert.equal(button.dataset.action, 'click->example#__perform')
+    assert.equal(button.dataset.controller, null)
+  })
+
+  it('should add an additional data-controller attribute to the reflex element if any parent element holds a data-controller attribute but controller doesnt exist', async () => {
+    const controllerElement = await fixture(html`
+      <div data-controller="example">
+        <a data-reflex="click->Example#click">Click</a>
+      </div>
+    `)
+
+    const button = controllerElement.children[0]
+
+    scanForReflexesOnElement(button)
+
+    // this element holds a data-controller="example" attribute but the `example` controller is not registered
+    assert.equal(controllerElement.dataset.controller, 'example')
+    assert.deepEqual(registeredControllers(), ['stimulus-reflex'])
+
+    assert.equal(button.dataset.reflex, 'click->Example#click')
+    assert.equal(button.dataset.action, 'click->stimulus-reflex#__perform')
+    assert.equal(button.dataset.controller, 'stimulus-reflex')
+  })
+
+  it('should use data-controller from reflex element when parent element also holds a controller instance', async () => {
+    App.app.register('example1', ExampleController)
+    App.app.register('example2', ExampleController)
+
+    const controllerElement = await fixture(html`
+      <div data-controller="example1">
+        <a data-reflex="click->Example#click" data-controller="example2"
+          >Click</a
+        >
+      </div>
+    `)
+
+    const button = controllerElement.children[0]
+
+    scanForReflexesOnElement(button)
+
+    assert.equal(controllerElement.dataset.controller, 'example1')
+
+    assert.equal(button.dataset.reflex, 'click->Example#click')
+    assert.equal(button.dataset.action, 'click->example2#__perform')
+    assert.equal(button.dataset.controller, 'example2')
+  })
+
+  it('should', async () => {
+    App.app.register('example', ExampleController)
+
+    const controllerElement = await fixture(html`
+      <div data-controller="example">
+        <a data-reflex="click->SomethingDifferent#click">Click</a>
+      </div>
+    `)
+
+    const button = controllerElement.children[0]
+
+    scanForReflexesOnElement(button)
+
+    assert.equal(controllerElement.dataset.controller, 'example')
+
+    assert.equal(button.dataset.reflex, 'click->SomethingDifferent#click')
+    assert.equal(button.dataset.action, 'click->example#__perform')
+    assert.equal(button.dataset.controller, undefined)
+  })
+
+  it('should use correct data-controller if element holds multiple controllers', async () => {
+    App.app.register('example', ExampleController)
+    App.app.register('something-different', ExampleController)
+
+    const button = await fixture(html`
+      <a
+        data-reflex="click->SomethingDifferent#click"
+        data-controller="example something-different"
+        >Click</a
+      >
+    `)
+
+    scanForReflexesOnElement(button)
+
+    assert.equal(button.dataset.reflex, 'click->SomethingDifferent#click')
+    assert.equal(button.dataset.action, 'click->something-different#__perform')
+    assert.equal(button.dataset.controller, 'example something-different')
+  })
+
+  it('should add stimulus-reflex data-controller if element holds controller but none matches', async () => {
+    App.app.register('example', ExampleController)
+
+    const button = await fixture(html`
+      <a
+        data-reflex="click->Example#click"
+        data-controller="something-different"
+        >Click</a
+      >
+    `)
+
+    scanForReflexesOnElement(button)
+
+    assert.equal(button.dataset.reflex, 'click->Example#click')
+    assert.equal(button.dataset.action, 'click->stimulus-reflex#__perform')
+    assert.equal(button.dataset.controller, 'something-different stimulus-reflex')
+  })
+
+  it('should use correct data-controller from parent if parent holds multiple controllers', async () => {
+    App.app.register('example', ExampleController)
+    App.app.register('something-different', ExampleController)
+
+    const controllerElement = await fixture(html`
+      <div data-controller="example something-different">
+        <a data-reflex="click->SomethingDifferent#click">Click</a>
+      </div>
+    `)
+
+    const button = controllerElement.children[0]
+
+    scanForReflexesOnElement(button)
+
+    assert.equal(
+      controllerElement.dataset.controller,
+      'example something-different'
+    )
+
+    assert.equal(button.dataset.reflex, 'click->SomethingDifferent#click')
+    assert.equal(button.dataset.action, 'click->something-different#__perform')
+    assert.equal(button.dataset.controller, undefined)
   })
 })

--- a/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
+++ b/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
@@ -224,7 +224,10 @@ describe('scanForReflexesOnElement', () => {
 
     assert.equal(button.dataset.reflex, 'click->Example#click')
     assert.equal(button.dataset.action, 'click->stimulus-reflex#__perform')
-    assert.equal(button.dataset.controller, 'something-different stimulus-reflex')
+    assert.equal(
+      button.dataset.controller,
+      'something-different stimulus-reflex'
+    )
   })
 
   it('should use correct data-controller from parent if parent holds multiple controllers', async () => {

--- a/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
+++ b/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
@@ -1,6 +1,7 @@
 import { html, fixture, assert } from '@open-wc/testing'
 
 import ExampleController from './dummy/example_controller'
+import RegularController from './dummy/regular_controller'
 
 import { application } from './dummy/application'
 import { initialize } from '../stimulus_reflex'
@@ -37,9 +38,9 @@ describe('scanForReflexesOnElement', () => {
     App.app.register('example', ExampleController)
 
     const element = await fixture(html`
-      <a data-controller="example" data-reflex="click->Example#handle"
-        >Handle</a
-      >
+      <a data-controller="example" data-reflex="click->Example#handle">
+        Handle
+      </a>
     `)
 
     scanForReflexesOnElement(element)
@@ -153,7 +154,7 @@ describe('scanForReflexesOnElement', () => {
 
     const controllerElement = await fixture(html`
       <div data-controller="example1">
-        <a data-reflex="click->Example#click" data-controller="example2"
+        <a data-reflex="click->Example2#click" data-controller="example2"
           >Click</a
         >
       </div>
@@ -165,12 +166,12 @@ describe('scanForReflexesOnElement', () => {
 
     assert.equal(controllerElement.dataset.controller, 'example1')
 
-    assert.equal(button.dataset.reflex, 'click->Example#click')
+    assert.equal(button.dataset.reflex, 'click->Example2#click')
     assert.equal(button.dataset.action, 'click->example2#__perform')
     assert.equal(button.dataset.controller, 'example2')
   })
 
-  it('should not add data-controller to reflex element if parent holds', async () => {
+  it('should not add data-controller to reflex element if parent holds a controller', async () => {
     App.app.register('example', ExampleController)
 
     const controllerElement = await fixture(html`
@@ -186,8 +187,8 @@ describe('scanForReflexesOnElement', () => {
     assert.equal(controllerElement.dataset.controller, 'example')
 
     assert.equal(button.dataset.reflex, 'click->SomethingDifferent#click')
-    assert.equal(button.dataset.action, 'click->example#__perform')
-    assert.equal(button.dataset.controller, undefined)
+    assert.equal(button.dataset.action, 'click->stimulus-reflex#__perform')
+    assert.equal(button.dataset.controller, 'stimulus-reflex')
   })
 
   it('should use correct data-controller if element holds multiple controllers', async () => {
@@ -198,8 +199,9 @@ describe('scanForReflexesOnElement', () => {
       <a
         data-reflex="click->SomethingDifferent#click"
         data-controller="example something-different"
-        >Click</a
       >
+        Click
+      </a>
     `)
 
     scanForReflexesOnElement(button)
@@ -216,8 +218,9 @@ describe('scanForReflexesOnElement', () => {
       <a
         data-reflex="click->Example#click"
         data-controller="something-different"
-        >Click</a
       >
+        Click
+      </a>
     `)
 
     scanForReflexesOnElement(button)
@@ -252,5 +255,21 @@ describe('scanForReflexesOnElement', () => {
     assert.equal(button.dataset.reflex, 'click->SomethingDifferent#click')
     assert.equal(button.dataset.action, 'click->something-different#__perform')
     assert.equal(button.dataset.controller, undefined)
+  })
+
+  it('should use stimulus-reflex controller if matching controller is not a StimulusReflex controller', async () => {
+    App.app.register('example', RegularController)
+
+    const element = await fixture(html`
+      <a data-reflex="click->Example#click" data-controller="example">
+        Click
+      </a>
+    `)
+
+    scanForReflexesOnElement(element)
+
+    assert.equal(element.dataset.reflex, 'click->Example#click')
+    assert.equal(element.dataset.action, 'click->stimulus-reflex#__perform')
+    assert.equal(element.dataset.controller, 'example stimulus-reflex')
   })
 })

--- a/javascript/test/utils.extractReflexName.test.js
+++ b/javascript/test/utils.extractReflexName.test.js
@@ -37,6 +37,22 @@ describe('extractReflexName', () => {
     })
   })
 
+  describe('when the reflex class is camelcased', () => {
+    it('returns namespaced reflex name', () => {
+      assert.equal(
+        extractReflexName('click->SomethingElseReflex#create'),
+        'SomethingElse'
+      )
+    })
+
+    it('returns namespaced reflex name', () => {
+      assert.equal(
+        extractReflexName('click->SomethingElse#create'),
+        'SomethingElse'
+      )
+    })
+  })
+
   describe('when the reflex class is namespaced', () => {
     it('returns namespaced reflex name', () => {
       assert.equal(

--- a/javascript/test/utils.reflexNameToControllerIdentifier.test.js
+++ b/javascript/test/utils.reflexNameToControllerIdentifier.test.js
@@ -1,0 +1,38 @@
+import { assert } from '@open-wc/testing'
+
+import { reflexNameToControllerIdentifier } from '../utils'
+
+describe('reflexNameToControllerIdentifier', () => {
+  describe('empty string', () => {
+    it('returns empty string', () => {
+      assert.equal(reflexNameToControllerIdentifier(''), '')
+    })
+  })
+
+  describe('regular reflex name', () => {
+    it('returns controller identifier', () => {
+      assert.equal(reflexNameToControllerIdentifier('Test'), 'test')
+      assert.equal(reflexNameToControllerIdentifier('TestReflex'), 'test')
+    })
+  })
+
+  describe('camelcased reflex name', () => {
+    it('returns controller identifier', () => {
+      assert.equal(reflexNameToControllerIdentifier('SomethingElse'), 'something-else')
+      assert.equal(reflexNameToControllerIdentifier('SomethingElseReflex'), 'something-else')
+    })
+  })
+
+  describe('namespaced reflex name', () => {
+    it('returns controller identifier', () => {
+      assert.equal(
+        reflexNameToControllerIdentifier('MyModule::Test'),
+        'my-module--test'
+      )
+      assert.equal(
+        reflexNameToControllerIdentifier('MyModule::TestReflex'),
+        'my-module--test'
+      )
+    })
+  })
+})

--- a/javascript/test/utils.reflexNameToControllerIdentifier.test.js
+++ b/javascript/test/utils.reflexNameToControllerIdentifier.test.js
@@ -18,8 +18,14 @@ describe('reflexNameToControllerIdentifier', () => {
 
   describe('camelcased reflex name', () => {
     it('returns controller identifier', () => {
-      assert.equal(reflexNameToControllerIdentifier('SomethingElse'), 'something-else')
-      assert.equal(reflexNameToControllerIdentifier('SomethingElseReflex'), 'something-else')
+      assert.equal(
+        reflexNameToControllerIdentifier('SomethingElse'),
+        'something-else'
+      )
+      assert.equal(
+        reflexNameToControllerIdentifier('SomethingElseReflex'),
+        'something-else'
+      )
     })
   })
 

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -173,6 +173,7 @@ const reflexNameToControllerIdentifier = (reflexName) => {
   return reflexName
     .replace(/([a-z0–9])([A-Z])/g, '$1-$2')
     .replace(/(::)/g, '--')
+    .replace(/-reflex$/gi, '')
     .toLowerCase()
 }
 

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -169,19 +169,27 @@ const getReflexRoots = element => {
   return list
 }
 
+const reflexNameToControllerIdentifier = (reflexName) => {
+  return reflexName
+    .replace(/([a-z0–9])([A-Z])/g, '$1-$2')
+    .replace(/(::)/g, '--')
+    .toLowerCase()
+}
+
 export {
-  uuidv4,
-  serializeForm,
   camelize,
   debounce,
   dispatch,
-  extractReflexName,
-  emitEvent,
-  elementToXPath,
-  XPathToElement,
-  XPathToArray,
   elementInvalid,
+  elementToXPath,
+  emitEvent,
+  extractReflexName,
   getReflexElement,
   getReflexOptions,
-  getReflexRoots
+  getReflexRoots,
+  reflexNameToControllerIdentifier,
+  serializeForm,
+  uuidv4,
+  XPathToArray,
+  XPathToElement,
 }


### PR DESCRIPTION
# Type of PR

Bug fix

## Description

There's was an edge case where we would add another `data-controller` attribute to the reflex element even if a parent element already had a matching controller instance.

This markup: 
```html
<div data-controller="example">
  <button 
    data-reflex="click->Example#increment"
  >Click</button>
</div>
```
would get transformed to:
```diff
<div data-controller="example">
  <button 
    data-reflex="click->Example#increment" 
+   data-controller="example" 
+   data-action="click->example#__perform"
  >Click</button>
</div>
```
Which ends up with two controller instances of `example` even if we actually just needed one.

This pull request optimizes this by just conditionally adding the `example` controller to the `data-controller` attribute on the reflex element.

Now with this pull request the end-result is just:
```diff
<div data-controller="example">
  <button 
    data-reflex="click->Example#increment" 
+   data-action="click->example#__perform"
  >Click</button>
</div>
```

## Why should this be added

We shouldn't create more controller instances than necessary. In this case it was apparent because the `connect()` callback was fired twice. To not fire the method twice we add the condition.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
