### PR TITLE
Fix typo in application_reflex generator template

### DIFF
--- a/lib/generators/stimulus_reflex/templates/app/reflexes/application_reflex.rb.tt
+++ b/lib/generators/stimulus_reflex/templates/app/reflexes/application_reflex.rb.tt
@@ -8,7 +8,7 @@ class ApplicationReflex < StimulusReflex::Reflex
   # If your ActionCable connection is: `identified_by :current_user`
   #   delegate :current_user, to: :connection
   #
-  # current_user delegation alloqs you to use the Current pattern, too:
+  # current_user delegation allows you to use the Current pattern, too:
   #   before_reflex do
   #     Current.user = current_user
   #   end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Documentation

## Description

Very minor typo in application_reflex generator template

## Why should this be added

Typos look unprofessional, and deeply offend those of us with OCD.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
