### PR TITLE
Improve DX around version mismatch warnings

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -27,24 +27,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           reflex.logger&.error error_message
           reflex.broadcast_error data: data, error: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
         else
-          if exception.is_a? StimulusReflex::Reflex::VersionMismatchError
-            mismatch = "Reflex failed due to stimulus_reflex gem/NPM package version mismatch. Package versions must match exactly.\nNote that if you are using pre-release builds, gems use the \"x.y.z.preN\" version format, while NPM packages use \"x.y.z-preN\".\n\nstimulus_reflex gem: #{StimulusReflex::VERSION}\nstimulus_reflex NPM: #{data["version"]}"
-
-            StimulusReflex.config.logger.error("\n\e[31m#{mismatch}\e[0m") unless StimulusReflex.config.on_failed_sanity_checks == :ignore
-
-            if Rails.env.development?
-              CableReady::Channels.instance[stream_name].console_log(
-                message: mismatch,
-                level: "error",
-                id: data["id"]
-              ).broadcast
-            end
-
-            if StimulusReflex.config.on_failed_sanity_checks == :exit
-              sleep 0.1
-              exit!
-            end
-          else
+          unless exception.is_a?(StimulusReflex::Reflex::VersionMismatchError)
             StimulusReflex.config.logger.error error_message
           end
 

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -1,5 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
+import './version_checker'
+
 import ActionCableTransport from './transports/action_cable'
 import App from './app'
 import Debug from './debug'

--- a/javascript/version_checker.js
+++ b/javascript/version_checker.js
@@ -1,0 +1,75 @@
+import Toastify from "toastify-js/src/toastify-es.js"
+import CableReady from "cable_ready"
+
+CableReady.operations.stimulusReflexVersionMismatch = operation => {
+  const levels = {
+    "info": {},
+    "success": { background: "rgb(0, 176, 155)" },
+    "warn": { background: "rgb(247, 187, 60)" },
+    "error": { background: "rgb(255, 95, 109)" },
+  }
+
+  const defaults = {
+    selector: setupToastify(),
+    close: true,
+    duration: 30 * 1000,
+    gravity: "bottom",
+    position: "right",
+    newWindow: true,
+    style: levels[operation.level || "info"]
+  }
+
+  Toastify({ ...defaults, ...operation }).showToast()
+}
+
+function setupToastify() {
+  const id = "stimulus-reflex-toast-element"
+  let element = document.querySelector(`#${id}`)
+
+  if (!element) {
+    element = document.createElement("div")
+    element.id = id
+    document.documentElement.appendChild(element)
+
+    const styles = document.createElement("style")
+    styles.innerHTML = `
+      #${id} .toastify {
+         padding: 12px 20px;
+         color: #ffffff;
+         display: inline-block;
+         box-shadow: 0 3px 6px -1px rgba(0, 0, 0, 0.12), 0 10px 36px -4px rgba(77, 96, 232, 0.3);
+         background: -webkit-linear-gradient(315deg, #73a5ff, #5477f5);
+         background: linear-gradient(135deg, #73a5ff, #5477f5);
+         position: fixed;
+         opacity: 0;
+         transition: all 0.4s cubic-bezier(0.215, 0.61, 0.355, 1);
+         border-radius: 2px;
+         cursor: pointer;
+         text-decoration: none;
+         max-width: calc(50% - 20px);
+         z-index: 2147483647;
+         bottom: -150px;
+         right: 15px;
+      }
+
+      #${id} .toastify.on {
+        opacity: 1;
+      }
+
+      #${id} .toast-close {
+        background: transparent;
+        border: 0;
+        color: white;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: 1em;
+        opacity: 0.4;
+        padding: 0 5px;
+      }
+    `
+
+    document.head.appendChild(styles)
+  }
+
+  return element
+}

--- a/javascript/version_checker.js
+++ b/javascript/version_checker.js
@@ -4,9 +4,9 @@ import CableReady from "cable_ready"
 CableReady.operations.stimulusReflexVersionMismatch = operation => {
   const levels = {
     "info": {},
-    "success": { background: "rgb(0, 176, 155)" },
-    "warn": { background: "rgb(247, 187, 60)" },
-    "error": { background: "rgb(255, 95, 109)" },
+    "success": { background: "#198754", color: "white" },
+    "warn": { background: "#ffc107", color: "black" },
+    "error": { background: "#dc3545", color: "white" },
   }
 
   const defaults = {
@@ -37,7 +37,6 @@ function setupToastify() {
          padding: 12px 20px;
          color: #ffffff;
          display: inline-block;
-         box-shadow: 0 3px 6px -1px rgba(0, 0, 0, 0.12), 0 10px 36px -4px rgba(77, 96, 232, 0.3);
          background: -webkit-linear-gradient(315deg, #73a5ff, #5477f5);
          background: linear-gradient(135deg, #73a5ff, #5477f5);
          position: fixed;

--- a/lib/stimulus_reflex/cable_ready_channels.rb
+++ b/lib/stimulus_reflex/cable_ready_channels.rb
@@ -7,6 +7,7 @@ module StimulusReflex
     def initialize(reflex)
       @stream_name = reflex.stream_name
       @id = reflex.id
+      CableReady.config.add_operation_name(:stimulus_reflex_version_mismatch)
     end
 
     def cable_ready_channels

--- a/lib/stimulus_reflex/reflex_data.rb
+++ b/lib/stimulus_reflex/reflex_data.rb
@@ -85,6 +85,10 @@ class StimulusReflex::ReflexData
     data["reflexController"]
   end
 
+  def npm_version
+    data["version"].to_s
+  end
+
   def version
     data["version"].to_s.gsub("-pre", ".pre")
   end

--- a/lib/stimulus_reflex/reflex_factory.rb
+++ b/lib/stimulus_reflex/reflex_factory.rb
@@ -20,7 +20,8 @@ class StimulusReflex::ReflexFactory
           reflex_controller: reflex_data.reflex_controller,
           permanent_attribute_name: reflex_data.permanent_attribute_name,
           suppress_logging: reflex_data.suppress_logging,
-          version: reflex_data.version
+          version: reflex_data.version,
+          npm_version: reflex_data.npm_version
         })
     end
 

--- a/lib/stimulus_reflex/version_checker.rb
+++ b/lib/stimulus_reflex/version_checker.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module StimulusReflex
+  class VersionMismatchError < StandardError
+  end
+
+  module VersionChecker
+    def check_version!
+      return if StimulusReflex.config.on_failed_sanity_checks == :ignore
+      return if version == StimulusReflex::VERSION
+
+      level = (StimulusReflex.config.on_failed_sanity_checks == :exit) ? "error" : "warn"
+      reason = (level == "error") ? "failed to execute your reflex action due to" : "noticed"
+
+      mismatch = "StimulusReflex #{reason} a version mismatch between your gem and JavaScript version. Package versions must match exactly.\n\nstimulus_reflex gem: #{StimulusReflex::VERSION}\nstimulus_reflex npm: #{npm_version}"
+
+      StimulusReflex.config.logger.error("\n\e[31m#{mismatch}\e[0m")
+
+      log = {
+        message: mismatch,
+        level: level,
+        reflexId: id
+      }
+
+      event = {
+        name: "stimulus-reflex:version-mismatch",
+        reflexId: id,
+        detail: {
+          message: mismatch,
+          gem: StimulusReflex::VERSION,
+          npm: npm_version,
+          level: level
+        }
+      }
+
+      toast = {
+        text: mismatch.to_s,
+        destination: "https://docs.stimulusreflex.com/hello-world/setup#upgrading-package-versions-and-sanity",
+        reflexId: id,
+        level: level
+      }
+
+      CableReady::Channels.instance[@channel.stream_name]
+        .console_log(log)
+        .dispatch_event(event)
+        .stimulus_reflex_version_mismatch(toast)
+        .broadcast
+
+      return if level == "warn"
+
+      raise VersionMismatchError.new(mismatch)
+    end
+  end
+end

--- a/lib/stimulus_reflex/version_checker.rb
+++ b/lib/stimulus_reflex/version_checker.rb
@@ -40,11 +40,11 @@ module StimulusReflex
         level: level
       }
 
-      CableReady::Channels.instance[@channel.stream_name]
-        .console_log(log)
-        .dispatch_event(event)
-        .stimulus_reflex_version_mismatch(toast)
-        .broadcast
+      CableReady::Channels.instance[@channel.stream_name].tap { |channel|
+        channel.console_log(log)
+        channel.dispatch_event(event)
+        channel.stimulus_reflex_version_mismatch(toast) if Rails.env.development?
+      }.broadcast
 
       return if level == "warn"
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@web/test-runner": "^0.15.1",
     "prettier-standard": "^16.4.1",
     "rollup": "^3.19.1",
+    "toastify-js": "^1.12.0",
     "vitepress": "^1.0.0-alpha.56"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4657,6 +4657,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toastify-js@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/toastify-js/-/toastify-js-1.12.0.tgz#cc1c4f5c7e7380e854e20bedceb51980ea29f64d"
+  integrity sha512-HeMHCO9yLPvP9k0apGSdPUWrUbLnxUKNFzgUoZp1PHCLploIX/4DSQ7V8H25ef+h4iO9n0he7ImfcndnN6nDrQ==
+
 toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"


### PR DESCRIPTION
# Type of PR 

Enhancement

## Description

This pull request enhances the developer experience when the StimulusReflex client- and server-side versions mismatch. It will show a toast message in the lower right corner of the screen if there's a version mismatch. Previously it would just show it in the Rails server log.

It will only show the toasts if you try to trigger a reflex action, it won't complain earlier, which is also much friendlier, because in previous versions of StimulusReflex it wouldn't even let you start the Rails server.

This is what happens now if you try to trigger a reflex:

* on `:exit` it will show a red error toast message and won't execute the trigged reflex:
![Screenshot 2023-03-13 at 15 43 43](https://user-images.githubusercontent.com/6411752/224736409-aac0d8bf-9d11-4dff-82ae-b9d7b0926b6b.png)

* on `:warn` it will show a yellow warning toast message but will still execute the triggered reflex:
![Screenshot 2023-03-13 at 15 43 28](https://user-images.githubusercontent.com/6411752/224735908-4b56f4ad-9537-48cc-8883-959cdafd399a.png)


* on `:ignore` it won't show anything and also will also regularly execute the triggered reflex. 

Note: the `toastify-js` dependency will be bundled up with the built JavaScript version of the package, so it won't show up as a runtime dependency in applications running the `stimulus_reflex` npm package.

The toasts are currently not disabled in production environments, but I'm also not sure if we should. Any opinions on this?

## Why should this be added

Improves the developer experience and makes it easier to noticed/work with.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
