### PR TITLE
fix: Deep merge url_params in ReflexData

### DIFF
--- a/lib/stimulus_reflex/reflex_data.rb
+++ b/lib/stimulus_reflex/reflex_data.rb
@@ -52,7 +52,7 @@ class StimulusReflex::ReflexData
   end
 
   def params
-    form_params.merge(url_params)
+    form_params.deep_merge(url_params)
   end
 
   def form_params

--- a/test/reflex_data_test.rb
+++ b/test/reflex_data_test.rb
@@ -6,7 +6,7 @@ class StimulusReflex::ReflexDataTest < ActiveSupport::TestCase
   reflex_data = StimulusReflex::ReflexData.new({
     "params" => {
       "user" => {"email" => "test@example.com"}
-                                                 },
+    },
     "url" => "http://example.com/?user[context]=regular"
   })
 

--- a/test/reflex_data_test.rb
+++ b/test/reflex_data_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class StimulusReflex::ReflexDataTest < ActiveSupport::TestCase
+  reflex_data = StimulusReflex::ReflexData.new({
+    "params" => {
+      "user" => {"email" => "test@example.com"}
+                                                 },
+    "url" => "http://example.com/?user[context]=regular"
+  })
+
+  test "accessing form_params keeps url_params with the same keys" do
+    assert_equal "regular", reflex_data.params["user"]["context"]
+    assert_equal "test@example.com", reflex_data.params["user"]["email"]
+  end
+end


### PR DESCRIPTION
# Type of PR

Bug Fix

## Description

Discord user laykou [reported a case](https://discord.com/channels/629472241427415060/733725826411135107/1086602257879011418) in which `url_params` in `ReflexData` were overriding `form_params` when having the same key.

This is solved here by `deep_merge`ing them.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
