### PR TITLE
Versions comparaison: `rc` is also a suffix (as `pre`).

### DIFF
--- a/javascript/process.js
+++ b/javascript/process.js
@@ -12,10 +12,10 @@ import { XPathToElement } from './utils'
 export const received = data => {
   if (!data.cableReady) return
 
-  if (data.version.replace('.pre', '-pre') !== CableReady.version) {
+  if (data.version.replace('.pre', '-pre').replace(".rc", "-rc") !== CableReady.version) {
     if (Debug.enabled)
       console.error(
-        `Reflex failed due to cable_ready gem/NPM package version mismatch. Package versions must match exactly.\nNote that if you are using pre-release builds, gems use the "x.y.z.preN" version format, while NPM packages use "x.y.z-preN".\n\ncable_ready gem: ${data.version}\ncable_ready NPM: ${CableReady.version}`
+        `Reflex failed due to cable_ready gem/NPM package version mismatch. Package versions must match exactly.\nNote that if you are using pre-release builds, gems use the "x.y.z.rcN" version format, while NPM packages use "x.y.z-rcN".\n\ncable_ready gem: ${data.version}\ncable_ready NPM: ${CableReady.version}`
       )
     return
   }

--- a/lib/stimulus_reflex/installer.rb
+++ b/lib/stimulus_reflex/installer.rb
@@ -94,11 +94,11 @@ end
 ### memoized values
 
 def sr_npm_version
-  @sr_npm_version ||= StimulusReflex::VERSION.gsub(".pre", "-pre")
+  @sr_npm_version ||= StimulusReflex::VERSION.gsub(".pre", "-pre").gsub(".rc", "-rc")
 end
 
 def cr_npm_version
-  @cr_npm_version ||= CableReady::VERSION.gsub(".pre", "-pre")
+  @cr_npm_version ||= CableReady::VERSION.gsub(".pre", "-pre").gsub(".rc", "-rc")
 end
 
 def package_json

--- a/lib/stimulus_reflex/reflex_data.rb
+++ b/lib/stimulus_reflex/reflex_data.rb
@@ -90,7 +90,7 @@ class StimulusReflex::ReflexData
   end
 
   def version
-    data["version"].to_s.gsub("-pre", ".pre")
+    data["version"].to_s.gsub("-pre", ".pre").gsub("-rc", ".rc")
   end
 
   private


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Simply add `rc` as suffix as `pre` is a suffix used in version. 


## Description
Simply add `rc` as suffix as `pre` is a suffix used in version. 

Fixes #649

## Why should this be added
Since the rc has been released, we should compare versions between gem and npm taking into account the `rc` suffix (and not only `pre`)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
