### PR TITLE
Show version mismatch warning toasts when CableReady versions mismatch

### DIFF
--- a/javascript/process.js
+++ b/javascript/process.js
@@ -13,10 +13,17 @@ export const received = data => {
   if (!data.cableReady) return
 
   if (data.version.replace('.pre', '-pre').replace(".rc", "-rc") !== CableReady.version) {
-    if (Debug.enabled)
-      console.error(
-        `Reflex failed due to cable_ready gem/NPM package version mismatch. Package versions must match exactly.\nNote that if you are using pre-release builds, gems use the "x.y.z.rcN" version format, while NPM packages use "x.y.z-rcN".\n\ncable_ready gem: ${data.version}\ncable_ready NPM: ${CableReady.version}`
-      )
+    const mismatch = `CableReady failed to execute your reflex action due to a version mismatch between your gem and JavaScript version. Package versions must match exactly.\n\ncable_ready gem: ${data.version}\ncable_ready npm: ${CableReady.version}`
+    
+    console.error(mismatch)
+
+    if (Debug.enabled) {
+      CableReady.operations.stimulusReflexVersionMismatch({
+        text: mismatch,
+        level: "error"
+      })
+    }
+    
     return
   }
 


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

Following up on #641 and #650, this pull request also shows version mismatch toasts when the CableReady versions don't match. Perviously it would just show toast messages when the StimulusReflex versions didn't match.

## Why should this be added

Previously this just showed a console error message when the user enabled the client-side `debug` option to `true`. Now this message is always printed, regular of the option. But additionally it now shows a version mismatch toast message when the `debug` option is set to `true`:
![Screenshot 2023-03-27 at 21 10 36](https://user-images.githubusercontent.com/6411752/228042658-ed9523cc-575d-47b3-aaf0-6ab33a47b140.png)

This helps to know what's up and why a reflex action might not have worked. If you didn't have the console open you wouldn't know why the reflex action didn't work.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
