### PR TITLE
Remove `ActiveSupport::Concern#prepended` usage for Rails 6

### DIFF
--- a/lib/stimulus_reflex/cable_readiness.rb
+++ b/lib/stimulus_reflex/cable_readiness.rb
@@ -2,9 +2,7 @@
 
 module StimulusReflex
   module CableReadiness
-    def cable_ready
-      @cable_ready
-    end
+    attr_reader :cable_ready
 
     def initialize(*args, **kwargs)
       super(*args, **kwargs)

--- a/lib/stimulus_reflex/cable_readiness.rb
+++ b/lib/stimulus_reflex/cable_readiness.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
-
 module StimulusReflex
   module CableReadiness
-    extend ActiveSupport::Concern
-
-    prepended do
-      attr_reader :cable_ready
+    def cable_ready
+      @cable_ready
     end
 
     def initialize(*args, **kwargs)

--- a/test/cable_readiness_test.rb
+++ b/test/cable_readiness_test.rb
@@ -2,20 +2,20 @@
 
 require_relative "test_helper"
 
+class MyReflexPrepended
+  prepend StimulusReflex::CableReadiness
+
+  def id
+    "123"
+  end
+
+  def stream_name
+    "123"
+  end
+end
+
 class StimulusReflex::CableReadinessTest < ActiveSupport::TestCase
   test "can be prepended" do
-    class MyReflexPrepended
-      prepend StimulusReflex::CableReadiness
-
-      def id
-        "123"
-      end
-
-      def stream_name
-        "123"
-      end
-    end
-
     reflex = MyReflexPrepended.new
     assert_includes reflex.methods, :cable_ready
   end

--- a/test/cable_readiness_test.rb
+++ b/test/cable_readiness_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class StimulusReflex::CableReadinessTest < ActiveSupport::TestCase
+  test "can be prepended" do
+    class MyReflexPrepended
+      prepend StimulusReflex::CableReadiness
+
+      def id
+        "123"
+      end
+
+      def stream_name
+        "123"
+      end
+    end
+
+    reflex = MyReflexPrepended.new
+    assert_includes reflex.methods, :cable_ready
+  end
+end


### PR DESCRIPTION
# Type of PR

Bug Fix 

## Description

`ActiveSupport::Concern#prepended` is only available in Rails 6.1+. Since we support `>= 5.2` we can't rely on the `prepended` callback in `lib/stimulus_reflex/cable_readiness.rb`

Fixes #656 

## Why should this be added

Since we can easily support Rails 5.2 and Rails 6.0 with this fix. Otherwise we would need to make StimulusReflex depend on Rails 6.1+, which seems rather dramatic.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
