### PR TITLE
Fix exception in ActionCable channel due to reflexes overwriting each other's data

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -12,66 +12,64 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
 
   def receive(data)
     begin
-      begin
-        reflex = StimulusReflex::ReflexFactory.new(self, data).call
-        delegate_call_to_reflex reflex
-      rescue => exception
-        error = exception_with_backtrace(exception)
-        error_message = "\e[31mReflex #{reflex.data.target} failed: #{error[:message]} [#{reflex.url}]\e[0m\n#{error[:stack]}"
+      reflex = StimulusReflex::ReflexFactory.new(self, data).call
+      delegate_call_to_reflex reflex
+    rescue => exception
+      error = exception_with_backtrace(exception)
+      error_message = "\e[31mReflex #{reflex.data.target} failed: #{error[:message]} [#{reflex.url}]\e[0m\n#{error[:stack]}"
 
-        if reflex
-          reflex.rescue_with_handler(exception)
-          reflex.logger&.error error_message
-          reflex.broadcast_error data: data, error: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
-        else
-          unless exception.is_a?(StimulusReflex::Reflex::VersionMismatchError)
-            StimulusReflex.config.logger.error error_message
-          end
-
-          if error_message.to_s.include? "No route matches"
-            initializer_path = Rails.root.join("config", "initializers", "stimulus_reflex.rb")
-
-            StimulusReflex.config.logger.warn <<~NOTE
-              \e[33mNOTE: StimulusReflex failed to locate a matching route and could not re-render the page.
-
-              If your app uses Rack middleware to rewrite part of the request path, you must enable those middleware modules in StimulusReflex.
-              The StimulusReflex initializer should be located at #{initializer_path}, or you can generate it with:
-
-                $ bundle exec rails generate stimulus_reflex:config
-
-              Configure any required middleware:
-
-                StimulusReflex.configure do |config|
-                  config.middleware.use FirstRackMiddleware
-                  config.middleware.use SecondRackMiddleware
-                end\e[0m
-
-            NOTE
-          end
-        end
-        return
-      end
-
-      if reflex.halted?
-        reflex.broadcast_halt data: data
-      elsif reflex.forbidden?
-        reflex.broadcast_forbid data: data
-      else
-        begin
-          reflex.broadcast(reflex.selectors, data)
-        rescue => exception
-          reflex.rescue_with_handler(exception)
-          error = exception_with_backtrace(exception)
-          reflex.broadcast_error data: data, error: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
-          reflex.logger&.error "\e[31mReflex failed to re-render: #{error[:message]} [#{reflex.url}]\e[0m\n#{error[:stack]}"
-        end
-      end
-    ensure
       if reflex
-        commit_session(reflex)
-        report_failed_basic_auth(reflex) if reflex.controller?
-        reflex.logger&.log_all_operations
+        reflex.rescue_with_handler(exception)
+        reflex.logger&.error error_message
+        reflex.broadcast_error data: data, error: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
+      else
+        unless exception.is_a?(StimulusReflex::Reflex::VersionMismatchError)
+          StimulusReflex.config.logger.error error_message
+        end
+
+        if error_message.to_s.include? "No route matches"
+          initializer_path = Rails.root.join("config", "initializers", "stimulus_reflex.rb")
+
+          StimulusReflex.config.logger.warn <<~NOTE
+            \e[33mNOTE: StimulusReflex failed to locate a matching route and could not re-render the page.
+
+            If your app uses Rack middleware to rewrite part of the request path, you must enable those middleware modules in StimulusReflex.
+            The StimulusReflex initializer should be located at #{initializer_path}, or you can generate it with:
+
+              $ bundle exec rails generate stimulus_reflex:config
+
+            Configure any required middleware:
+
+              StimulusReflex.configure do |config|
+                config.middleware.use FirstRackMiddleware
+                config.middleware.use SecondRackMiddleware
+              end\e[0m
+
+          NOTE
+        end
       end
+      return
+    end
+
+    if reflex.halted?
+      reflex.broadcast_halt data: data
+    elsif reflex.forbidden?
+      reflex.broadcast_forbid data: data
+    else
+      begin
+        reflex.broadcast(reflex.selectors, data)
+      rescue => exception
+        reflex.rescue_with_handler(exception)
+        error = exception_with_backtrace(exception)
+        reflex.broadcast_error data: data, error: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
+        reflex.logger&.error "\e[31mReflex failed to re-render: #{error[:message]} [#{reflex.url}]\e[0m\n#{error[:stack]}"
+      end
+    end
+  ensure
+    if reflex
+      commit_session(reflex)
+      report_failed_basic_auth(reflex) if reflex.controller?
+      reflex.logger&.log_all_operations
     end
   end
 

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -12,21 +12,21 @@ class StimulusReflex::Reflex
   include CableReady::Identifiable
 
   attr_accessor :payload, :headers
-  attr_reader :channel, :data, :broadcaster
+  attr_reader :channel, :reflex_data, :broadcaster
 
   delegate :connection, :stream_name, to: :channel
   delegate :controller_class, :flash, :session, to: :request
   delegate :broadcast, :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
 
   # TODO remove xpath_controller and xpath_element for v4
-  delegate :url, :element, :selectors, :method_name, :form_params, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, to: :data
+  delegate :url, :element, :selectors, :method_name, :form_params, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, to: :reflex_data
   # END TODO: remove
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
 
-  def initialize(channel, data:)
+  def initialize(channel, reflex_data:)
     @channel = channel
-    @data = data
+    @reflex_data = reflex_data
     @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     @payload = {}
     @headers = {}

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -19,20 +19,7 @@ class StimulusReflex::Reflex
   delegate :broadcast, :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
 
   # TODO remove xpath_controller and xpath_element for v4
-  delegate :url,
-           :element,
-           :selectors,
-           :method_name,
-           :form_params,
-           :id,
-           :tab_id,
-           :reflex_controller,
-           :xpath_controller,
-           :xpath_element,
-           :permanent_attribute_name,
-           :version,
-           :suppress_logging,
-           to: :data
+  delegate :url, :element, :selectors, :method_name, :form_params, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, to: :data
   # END TODO: remove
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
@@ -46,7 +33,7 @@ class StimulusReflex::Reflex
 
     check_version!
 
-    self.params
+    params
   end
 
   # TODO: remove this for v4
@@ -57,7 +44,7 @@ class StimulusReflex::Reflex
   # END TODO: remove
 
   def logger
-    StimulusReflex::Logger.new(self) unless suppress_logging
+    @logger ||= StimulusReflex::Logger.new(self) unless suppress_logging
   end
 
   def request

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -19,7 +19,7 @@ class StimulusReflex::Reflex
   delegate :broadcast, :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
 
   # TODO remove xpath_controller and xpath_element for v4
-  delegate :url, :element, :selectors, :method_name, :form_params, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :npm_version, :suppress_logging, to: :reflex_data
+  delegate :url, :element, :selectors, :method_name, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :npm_version, :suppress_logging, to: :reflex_data
   # END TODO: remove
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
@@ -32,8 +32,6 @@ class StimulusReflex::Reflex
     @headers = {}
 
     check_version!
-
-    params
   end
 
   # TODO: remove this for v4
@@ -77,7 +75,7 @@ class StimulusReflex::Reflex
       req = ActionDispatch::Request.new(env)
 
       # fetch path params (controller, action, ...) and apply them
-      request_params = StimulusReflex::RequestParameters.new(params: form_params, req: req, url: url)
+      request_params = StimulusReflex::RequestParameters.new(params: reflex_data.params, req: req, url: url)
       req = request_params.apply!
 
       req

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -19,7 +19,7 @@ class StimulusReflex::Reflex
   delegate :broadcast, :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
 
   # TODO remove xpath_controller and xpath_element for v4
-  delegate :url, :element, :selectors, :method_name, :form_params, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :suppress_logging, to: :reflex_data
+  delegate :url, :element, :selectors, :method_name, :form_params, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :npm_version, :suppress_logging, to: :reflex_data
   # END TODO: remove
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name

--- a/lib/stimulus_reflex/reflex_data.rb
+++ b/lib/stimulus_reflex/reflex_data.rb
@@ -4,7 +4,7 @@ class StimulusReflex::ReflexData
   attr_reader :data
 
   def initialize(data)
-    @data = data
+    @data = data.deep_transform_keys { |k| k.to_s.underscore }.with_indifferent_access
   end
 
   def reflex_name
@@ -14,13 +14,13 @@ class StimulusReflex::ReflexData
   end
 
   def selectors
-    selectors = (data["selectors"] || []).select(&:present?)
-    selectors = data["selectors"] = ["body"] if selectors.blank?
+    selectors = (data[:selectors] || []).select(&:present?)
+    selectors = data[:selectors] = ["body"] if selectors.blank?
     selectors
   end
 
   def target
-    data["target"].to_s
+    data[:target].to_s
   end
 
   def method_name
@@ -28,11 +28,11 @@ class StimulusReflex::ReflexData
   end
 
   def arguments
-    (data["args"] || []).map { |arg| object_with_indifferent_access arg } || []
+    (data[:args] || []).map { |arg| object_with_indifferent_access arg } || []
   end
 
   def url
-    data["url"].to_s
+    data[:url].to_s
   end
 
   def element
@@ -40,15 +40,15 @@ class StimulusReflex::ReflexData
   end
 
   def permanent_attribute_name
-    data["permanentAttributeName"]
+    data[:permanent_attribute_name]
   end
 
   def suppress_logging
-    data["suppressLogging"]
+    data[:suppress_logging]
   end
 
   def form_data
-    Rack::Utils.parse_nested_query(data["formData"])
+    Rack::Utils.parse_nested_query(data[:form_data])
   end
 
   def params
@@ -56,7 +56,7 @@ class StimulusReflex::ReflexData
   end
 
   def form_params
-    form_data.deep_merge(data["params"] || {})
+    form_data.deep_merge(data[:params] || {})
   end
 
   def url_params
@@ -64,33 +64,33 @@ class StimulusReflex::ReflexData
   end
 
   def id
-    data["id"]
+    data[:id]
   end
 
   def tab_id
-    data["tabId"]
+    data[:tab_id]
   end
 
   # TODO: remove this in v4
   def xpath_controller
-    data["xpathController"]
+    data[:xpath_controller]
   end
 
   def xpath_element
-    data["xpathElement"]
+    data[:xpath_element]
   end
   # END TODO remove
 
   def reflex_controller
-    data["reflexController"]
+    data[:reflex_controller]
   end
 
   def npm_version
-    data["version"].to_s
+    data[:version].to_s
   end
 
   def version
-    data["version"].to_s.gsub("-pre", ".pre").gsub("-rc", ".rc")
+    npm_version.gsub("-pre", ".pre").gsub("-rc", ".rc")
   end
 
   private

--- a/lib/stimulus_reflex/reflex_factory.rb
+++ b/lib/stimulus_reflex/reflex_factory.rb
@@ -11,7 +11,7 @@ class StimulusReflex::ReflexFactory
   end
 
   def call
-    reflex_class.new(channel, data:)
+    reflex_class.new(channel, data: data)
   end
 
   private

--- a/lib/stimulus_reflex/reflex_factory.rb
+++ b/lib/stimulus_reflex/reflex_factory.rb
@@ -1,36 +1,26 @@
 # frozen_string_literal: true
 
 class StimulusReflex::ReflexFactory
-  class << self
-    attr_reader :reflex_data
+  attr_reader :channel, :data
 
-    def create_reflex_from_data(channel, reflex_data)
-      @reflex_data = reflex_data
-      reflex_class.new(channel,
-        url: reflex_data.url,
-        element: reflex_data.element,
-        selectors: reflex_data.selectors,
-        method_name: reflex_data.method_name,
-        params: reflex_data.params,
-        client_attributes: {
-          id: reflex_data.id,
-          tab_id: reflex_data.tab_id,
-          xpath_controller: reflex_data.xpath_controller,
-          xpath_element: reflex_data.xpath_element,
-          reflex_controller: reflex_data.reflex_controller,
-          permanent_attribute_name: reflex_data.permanent_attribute_name,
-          suppress_logging: reflex_data.suppress_logging,
-          version: reflex_data.version,
-          npm_version: reflex_data.npm_version
-        })
-    end
+  delegate :reflex_name, to: :data
 
-    def reflex_class
-      reflex_data.reflex_name.constantize.tap { |klass| raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex") unless is_reflex?(klass) }
-    end
+  def initialize(channel, data)
+    @channel = channel
+    @data = StimulusReflex::ReflexData.new(data)
+  end
 
-    def is_reflex?(klass)
-      klass.ancestors.include? StimulusReflex::Reflex
+  def call
+    reflex_class.new(channel, data:)
+  end
+
+  private
+
+  def reflex_class
+    reflex_name.constantize.tap do |klass|
+      unless klass.ancestors.include?(StimulusReflex::Reflex)
+        raise ArgumentError.new("#{reflex_name} is not a StimulusReflex::Reflex")
+      end
     end
   end
 end

--- a/test/broadcasters/broadcaster_test_case.rb
+++ b/test/broadcasters/broadcaster_test_case.rb
@@ -35,7 +35,7 @@ class StimulusReflex::BroadcasterTestCase < ActionCable::Channel::TestCase
       @env ||= {}
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", id: "666", version: StimulusReflex::VERSION)
-    @reflex = StimulusReflex::Reflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", id: "666", version: StimulusReflex::VERSION)
+    @reflex = StimulusReflex::Reflex.new(subscribe, reflex_data: reflex_data)
   end
 end

--- a/test/broadcasters/broadcaster_test_case.rb
+++ b/test/broadcasters/broadcaster_test_case.rb
@@ -34,6 +34,8 @@ class StimulusReflex::BroadcasterTestCase < ActionCable::Channel::TestCase
     def connection.env
       @env ||= {}
     end
-    @reflex = StimulusReflex::Reflex.new(subscribe, url: "https://test.stimulusreflex.com", client_attributes: {id: "666", version: StimulusReflex::VERSION})
+
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", id: "666", version: StimulusReflex::VERSION)
+    @reflex = StimulusReflex::Reflex.new(subscribe, data: data)
   end
 end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -29,8 +29,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = BeforeCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = BeforeCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
   end
@@ -46,8 +46,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = BeforeBlockCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = BeforeBlockCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
   end
@@ -67,8 +67,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = AfterCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = AfterCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 1, reflex.instance_variable_get(:@count)
   end
@@ -84,8 +84,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = AfterBlockCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = AfterBlockCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 1, reflex.instance_variable_get(:@count)
   end
@@ -107,8 +107,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = AroundCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = AroundCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 14, reflex.instance_variable_get(:@count)
   end
@@ -136,8 +136,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = CallbackOrderReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = CallbackOrderReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 3, reflex.instance_variable_get(:@count)
   end
@@ -177,8 +177,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = IfCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = IfCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 23, reflex.instance_variable_get(:@count)
   end
@@ -210,8 +210,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = IfProcCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = IfProcCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 23, reflex.instance_variable_get(:@count)
   end
@@ -251,8 +251,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = UnlessCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = UnlessCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 23, reflex.instance_variable_get(:@count)
   end
@@ -284,8 +284,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = UnlessProcCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = UnlessProcCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 23, reflex.instance_variable_get(:@count)
   end
@@ -319,8 +319,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#decrement", version: StimulusReflex::VERSION)
-    reflex = OnlyCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#decrement", version: StimulusReflex::VERSION)
+    reflex = OnlyCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:decrement)
     assert_equal(-8, reflex.instance_variable_get(:@count))
   end
@@ -354,13 +354,13 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = ExceptCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = ExceptCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#decrement", version: StimulusReflex::VERSION)
-    reflex = ExceptCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#decrement", version: StimulusReflex::VERSION)
+    reflex = ExceptCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:decrement)
     assert_equal(-8, reflex.instance_variable_get(:@count))
   end
@@ -394,8 +394,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = SkipBeforeCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SkipBeforeCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
   end
@@ -429,8 +429,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = SkipAfterCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SkipAfterCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 1, reflex.instance_variable_get(:@count)
   end
@@ -468,8 +468,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = SkipAroundCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SkipAroundCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 7, reflex.instance_variable_get(:@count)
   end
@@ -498,8 +498,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = InheritedSkipApplicationReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = InheritedSkipApplicationReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
   end
@@ -524,8 +524,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = SimplePrependBeforeCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SimplePrependBeforeCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 3, reflex.instance_variable_get(:@count)
   end
@@ -545,8 +545,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = BlockPrependBeforeCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = BlockPrependBeforeCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 3, reflex.instance_variable_get(:@count)
   end
@@ -576,8 +576,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = InheritedPrependBeforeCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = InheritedPrependBeforeCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 9, reflex.instance_variable_get(:@count)
   end
@@ -606,8 +606,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = SimplePrependAroundCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SimplePrependAroundCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 26, reflex.instance_variable_get(:@count)
   end
@@ -632,8 +632,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = SimplePrependAfterCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SimplePrependAfterCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 9, reflex.instance_variable_get(:@count)
   end
@@ -665,8 +665,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
-    reflex = AppendCallbackReflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = AppendCallbackReflex.new(subscribe, reflex_data: reflex_data)
     reflex.process(:increment)
     assert_equal 25, reflex.instance_variable_get(:@count)
   end

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -29,7 +29,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = BeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = BeforeCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
   end
@@ -45,7 +46,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = BeforeBlockCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = BeforeBlockCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
   end
@@ -65,7 +67,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = AfterCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = AfterCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 1, reflex.instance_variable_get(:@count)
   end
@@ -81,7 +84,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = AfterBlockCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = AfterBlockCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 1, reflex.instance_variable_get(:@count)
   end
@@ -103,7 +107,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = AroundCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = AroundCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 14, reflex.instance_variable_get(:@count)
   end
@@ -131,7 +136,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = CallbackOrderReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = CallbackOrderReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 3, reflex.instance_variable_get(:@count)
   end
@@ -171,7 +177,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = IfCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = IfCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 23, reflex.instance_variable_get(:@count)
   end
@@ -203,7 +210,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = IfProcCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = IfProcCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 23, reflex.instance_variable_get(:@count)
   end
@@ -243,7 +251,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = UnlessCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = UnlessCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 23, reflex.instance_variable_get(:@count)
   end
@@ -275,7 +284,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = UnlessProcCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = UnlessProcCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 23, reflex.instance_variable_get(:@count)
   end
@@ -309,7 +319,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = OnlyCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :decrement, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#decrement", version: StimulusReflex::VERSION)
+    reflex = OnlyCallbackReflex.new(subscribe, data: data)
     reflex.process(:decrement)
     assert_equal(-8, reflex.instance_variable_get(:@count))
   end
@@ -317,7 +328,7 @@ class CallbacksTest < ActionCable::Channel::TestCase
   test "except option works" do
     class ExceptCallbackReflex < StimulusReflex::Reflex
       before_reflex :init
-      before_reflex :increment_bonus, except: [:decrement]
+      before_reflex :increment_bonus, except: :decrement
       before_reflex :decrement_bonus, except: :increment
 
       def increment
@@ -343,11 +354,13 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = ExceptCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = ExceptCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
 
-    reflex = ExceptCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :decrement, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#decrement", version: StimulusReflex::VERSION)
+    reflex = ExceptCallbackReflex.new(subscribe, data: data)
     reflex.process(:decrement)
     assert_equal(-8, reflex.instance_variable_get(:@count))
   end
@@ -381,7 +394,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = SkipBeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SkipBeforeCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
   end
@@ -415,7 +429,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = SkipAfterCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SkipAfterCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 1, reflex.instance_variable_get(:@count)
   end
@@ -453,7 +468,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = SkipAroundCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SkipAroundCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 7, reflex.instance_variable_get(:@count)
   end
@@ -482,7 +498,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = InheritedSkipApplicationReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = InheritedSkipApplicationReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 6, reflex.instance_variable_get(:@count)
   end
@@ -507,7 +524,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = SimplePrependBeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SimplePrependBeforeCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 3, reflex.instance_variable_get(:@count)
   end
@@ -527,7 +545,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = BlockPrependBeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = BlockPrependBeforeCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 3, reflex.instance_variable_get(:@count)
   end
@@ -557,7 +576,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = InheritedPrependBeforeCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = InheritedPrependBeforeCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 9, reflex.instance_variable_get(:@count)
   end
@@ -586,7 +606,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = SimplePrependAroundCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SimplePrependAroundCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 26, reflex.instance_variable_get(:@count)
   end
@@ -611,7 +632,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = SimplePrependAfterCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = SimplePrependAfterCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 9, reflex.instance_variable_get(:@count)
   end
@@ -643,7 +665,8 @@ class CallbacksTest < ActionCable::Channel::TestCase
       end
     end
 
-    reflex = AppendCallbackReflex.new(subscribe, url: "https://test.stimulusreflex.com", method_name: :increment, client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", target: "test#increment", version: StimulusReflex::VERSION)
+    reflex = AppendCallbackReflex.new(subscribe, data: data)
     reflex.process(:increment)
     assert_equal 25, reflex.instance_variable_get(:@count)
   end

--- a/test/reflex_test.rb
+++ b/test/reflex_test.rb
@@ -34,13 +34,12 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
   end
 
   test "params behave like ActionController::Parameters" do
-    ActionDispatch::Request.any_instance.stubs(:parameters).returns({"a" => "1", "b" => "2", "c" => "3"})
-    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", version: StimulusReflex::VERSION)
+    params = {"a" => "1", "b" => "2", "c" => "3"}
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", params: params, version: StimulusReflex::VERSION)
     reflex = StimulusReflex::Reflex.new(subscribe, reflex_data: reflex_data)
-
     deleted_param = reflex.params.delete("a")
 
     assert deleted_param == "1"
-    assert reflex.params.to_unsafe_h == {"b" => "2", "c" => "3"}
+    assert reflex.params.to_unsafe_h == {"controller" => "test", "action" => "index", "b" => "2", "c" => "3"}
   end
 end

--- a/test/reflex_test.rb
+++ b/test/reflex_test.rb
@@ -12,8 +12,8 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
       @env ||= {}
     end
 
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", id: "666", version: StimulusReflex::VERSION)
-    @reflex = StimulusReflex::Reflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", id: "666", version: StimulusReflex::VERSION)
+    @reflex = StimulusReflex::Reflex.new(subscribe, reflex_data: reflex_data)
     @reflex.controller_class.view_paths << Rails.root.join("test/views")
   end
 
@@ -35,8 +35,8 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
 
   test "params behave like ActionController::Parameters" do
     ActionDispatch::Request.any_instance.stubs(:parameters).returns({"a" => "1", "b" => "2", "c" => "3"})
-    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", version: StimulusReflex::VERSION)
-    reflex = StimulusReflex::Reflex.new(subscribe, data: data)
+    reflex_data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", version: StimulusReflex::VERSION)
+    reflex = StimulusReflex::Reflex.new(subscribe, reflex_data: reflex_data)
 
     deleted_param = reflex.params.delete("a")
 

--- a/test/reflex_test.rb
+++ b/test/reflex_test.rb
@@ -11,7 +11,9 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
     def connection.env
       @env ||= {}
     end
-    @reflex = StimulusReflex::Reflex.new(subscribe, url: "https://test.stimulusreflex.com", client_attributes: {id: "666", version: StimulusReflex::VERSION})
+
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", id: "666", version: StimulusReflex::VERSION)
+    @reflex = StimulusReflex::Reflex.new(subscribe, data: data)
     @reflex.controller_class.view_paths << Rails.root.join("test/views")
   end
 
@@ -33,7 +35,8 @@ class StimulusReflex::ReflexTest < ActionCable::Channel::TestCase
 
   test "params behave like ActionController::Parameters" do
     ActionDispatch::Request.any_instance.stubs(:parameters).returns({"a" => "1", "b" => "2", "c" => "3"})
-    reflex = StimulusReflex::Reflex.new(subscribe, url: "https://test.stimulusreflex.com", client_attributes: {version: StimulusReflex::VERSION})
+    data = StimulusReflex::ReflexData.new(url: "https://test.stimulusreflex.com", version: StimulusReflex::VERSION)
+    reflex = StimulusReflex::Reflex.new(subscribe, data: data)
 
     deleted_param = reflex.params.delete("a")
 


### PR DESCRIPTION
# Bug fix + refactoring

## Description

Think of a page with multiple StimulusReflex controllers hooked up to the `stimulus-reflex:connected` event and the markup (Haml in this example) looking something like this:

```haml
%div{ data: { controller: "sandwich", action: "stimulus-reflex:connected@document->sandwich#eat" } }

%div{ data: { controller: "tea", action: "stimulus-reflex:connected@document->tea#drink" } }
```

The actions are backed by simple JavaScript controllers and reflex actions looking as follows. The reflex actions have different arity: one take no arguments, the other takes one.

```js
// sandwich.js:

eat() {
  this.stimulate("Sandwich#eat");
}

// tea.js:

drink() {
  this.stimulate("Tea#drink", "green");
}
```

```ruby
# sandwich_reflex.rb:

class SandwichReflex < ApplicationReflex
  def eat
    # ...
  end
end

# tea_reflex.rb:

class TeaReflex < ApplicationReflex
  def drink(flavour)
    # ...
  end
end
```

This kind of setup creates a situation where `StimulusReflex::Channel#receive` is invoked twice in a very short period of time. And since both messages are processed by the **same instance** of the ActionCable channel (as can be verified by printing  out `self.object_id` at the beginning of the method), the use of an instance variable (`@reflex_data`) in the current implementation leads to a situation where it gets overrwritten by the second message before the first one has been processed. As a result, `reflex_data` inside `#delegate_call_to_reflex` ends up containing the same set of data which, after being checked against the method signature of both of the reflex actions, raises an `ArgumentError` due to arity mismatch.

This pull request fixes the issue by eliminating the use of instance variables inside `StimulusReflex::Channel#receive` in favour of bundling the message payload with the respective instance of the reflex. It also simplifies the reflex factory and constructor by delegating most of the calls to the `StimulusReflex::ReflexData` instance.

## Why should this be added

In modern web applications, it is common to load parts of the page asynchronously for a more responsive user experience. With StimulusReflex, it is most easily achieved by hooking up to the `stimulus-reflex:connected` event. This pull request fixes an exception that prevented the use of the specified event with multiple reflexes.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing