### PR TITLE
Fix reference to VersionMismatchError after namespace change

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "stimulus_reflex/version_checker"
+
 class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.constantize
   attr_reader :reflex_data
 
@@ -27,7 +29,7 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
           reflex.logger&.error error_message
           reflex.broadcast_error data: data, error: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
         else
-          unless exception.is_a?(StimulusReflex::Reflex::VersionMismatchError)
+          unless exception.is_a?(StimulusReflex::VersionMismatchError)
             StimulusReflex.config.logger.error error_message
           end
 

--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "stimulus_reflex/version_checker"
-
 class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.constantize
   attr_reader :reflex_data
 


### PR DESCRIPTION
# Bug fix

## Description

This reference to `StimulusReflex::Reflex::VersionMismatchError` in `StimulusReflex::Channel` is using an old namespace that was changed recently to `StimulusReflex::VersionMismatchError`.

## Why should this be added

Fixes #664 reported by @obie, additional discussion here: https://discord.com/channels/629472241427415060/733725826411135107/1113306088796864615

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
