### PR TITLE
Don't choose first controller if no matching StimulusReflex-enabled controller was found

### DIFF
--- a/javascript/controllers.js
+++ b/javascript/controllers.js
@@ -43,7 +43,7 @@ const findControllerByReflexName = (reflexName, controllers) => {
     return identifier === controller.identifier
   })
 
-  return controller || controllers[0]
+  return controller
 }
 
 export { allReflexControllers, findControllerByReflexName }

--- a/javascript/controllers.js
+++ b/javascript/controllers.js
@@ -46,4 +46,4 @@ const findControllerByReflexName = (reflexName, controllers) => {
   return controller
 }
 
-export { allReflexControllers, findControllerByReflexName }
+export { localReflexControllers, allReflexControllers, findControllerByReflexName }

--- a/javascript/scanner.js
+++ b/javascript/scanner.js
@@ -28,7 +28,7 @@ const scanForReflexesOnElement = (element, controller = null) => {
   )
 
   reflexAttributeNames.forEach(reflexName => {
-    const potentialControllers = [controller].concat(allReflexControllers(element))
+    const potentialControllers = [controller].concat(allReflexControllers(element)).filter(c => c)
 
     controller = findControllerByReflexName(
       reflexName,
@@ -42,7 +42,7 @@ const scanForReflexesOnElement = (element, controller = null) => {
 
     const parentControllerElement = element.closest(`[data-controller~=${controllerName}]`)
 
-    if (!parentControllerElement) {
+    if (!parentControllerElement || (parentControllerElement && controllerName === 'stimulus-reflex')) {
       controllers.push(controllerName)
     }
   })

--- a/javascript/scanner.js
+++ b/javascript/scanner.js
@@ -28,7 +28,7 @@ const scanForReflexesOnElement = (element, controller = null) => {
   )
 
   reflexAttributeNames.forEach(reflexName => {
-    const potentialControllers = [controller].concat(allReflexControllers(element)).filter(c => c)
+    const potentialControllers = [controller].concat(allReflexControllers(element))
 
     controller = findControllerByReflexName(
       reflexName,
@@ -42,7 +42,9 @@ const scanForReflexesOnElement = (element, controller = null) => {
 
     const parentControllerElement = element.closest(`[data-controller~=${controllerName}]`)
 
-    if (!parentControllerElement || (parentControllerElement && controllerName === 'stimulus-reflex')) {
+    const elementPrevisoulyHadStimulusReflexController = (element === parentControllerElement && controllerName === 'stimulus-reflex')
+
+    if (!parentControllerElement || elementPrevisoulyHadStimulusReflexController) {
       controllers.push(controllerName)
     }
   })

--- a/javascript/test/attributes.attributeValue.test.js
+++ b/javascript/test/attributes.attributeValue.test.js
@@ -31,6 +31,13 @@ describe('attributeValue', () => {
     )
   })
 
+  it('returns expected attribute value for array with duplicate values', () => {
+    assert.equal(
+      attributeValue(['one', 'two', 'three', 'three', 'two', 'one']),
+      'one two three'
+    )
+  })
+
   it('returns expected attribute value for array with mixed and duplicate values', () => {
     assert.equal(
       attributeValue([

--- a/javascript/test/controllers.allReflexControllers.test.js
+++ b/javascript/test/controllers.allReflexControllers.test.js
@@ -1,0 +1,111 @@
+import { html, fixture, assert, nextFrame } from '@open-wc/testing'
+import refute from './refute'
+
+import ExampleController from './dummy/example_controller'
+import RegularController from './dummy/regular_controller'
+
+import { initialize } from '../stimulus_reflex'
+
+import App from '../app'
+import { application } from './dummy/application'
+import { allReflexControllers } from '../controllers'
+
+import { unloadAllControllers, registeredControllers, identifiers } from './test_helpers'
+
+describe('allReflexControllers', () => {
+  beforeEach(() => {
+    initialize(application)
+  })
+
+  afterEach(() => {
+    unloadAllControllers()
+  })
+
+  it('returns StimulusReflex-enabled controller from parent', async () => {
+    App.app.register("sr", ExampleController)
+
+    assert.deepEqual(registeredControllers(), [
+      "stimulus-reflex",
+      "sr"
+    ])
+
+    const element = await fixture(html`
+      <div data-controller="sr">
+        <a></a>
+      </div>
+    `)
+
+    const a = element.querySelector('a')
+    assert.deepEqual(identifiers(allReflexControllers(a)), ["sr"])
+  })
+
+  it('doesnt return regular controller from parent', async () => {
+    App.app.register("regular", RegularController)
+
+    assert.deepEqual(registeredControllers(), [
+      "stimulus-reflex",
+      "regular"
+    ])
+
+    const element = await fixture(html`
+      <div data-controller="regular">
+        <a></a>
+      </div>
+    `)
+
+    const a = element.querySelector('a')
+    assert.isEmpty(identifiers(allReflexControllers(a)))
+  })
+
+  it('should return all reflex controllers from parents', async () => {
+    App.app.register("sr-one", ExampleController)
+    App.app.register("sr-two", ExampleController)
+    App.app.register("regular-one", RegularController)
+    App.app.register("regular-two", RegularController)
+
+    const element = await fixture(html`
+      <div data-controller="sr-one">
+        <div data-controller="sr-two">
+          <div data-controller="regular-one">
+            <div data-controller="regular-two">
+              <a></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    `)
+
+    const a = element.querySelector('a')
+
+    const controllers = allReflexControllers(a)
+
+    assert.deepEqual(identifiers(controllers), [
+      "sr-two",
+      "sr-one",
+    ])
+  })
+
+  it('should return controllers with same name', async () => {
+    App.app.register("sr", ExampleController)
+
+    const outer = await fixture(html`
+      <div data-controller="sr" id="outer">
+        <div data-controller="sr" id="inner">
+          <a></a>
+        </div>
+      </div>
+    `)
+
+    const a = outer.querySelector('a')
+    const inner = outer.querySelector('#inner')
+    const controllers = allReflexControllers(a)
+
+    assert.deepEqual(identifiers(controllers), [
+      "sr",
+      "sr",
+    ])
+
+    assert.deepEqual(controllers[0].element, inner)
+    assert.deepEqual(controllers[1].element, outer)
+  })
+})

--- a/javascript/test/controllers.allReflexControllers.test.js
+++ b/javascript/test/controllers.allReflexControllers.test.js
@@ -10,7 +10,11 @@ import App from '../app'
 import { application } from './dummy/application'
 import { allReflexControllers } from '../controllers'
 
-import { unloadAllControllers, registeredControllers, identifiers } from './test_helpers'
+import {
+  unloadAllControllers,
+  registeredControllers,
+  identifiers
+} from './test_helpers'
 
 describe('allReflexControllers', () => {
   beforeEach(() => {
@@ -22,12 +26,9 @@ describe('allReflexControllers', () => {
   })
 
   it('returns StimulusReflex-enabled controller from parent', async () => {
-    App.app.register("sr", ExampleController)
+    App.app.register('sr', ExampleController)
 
-    assert.deepEqual(registeredControllers(), [
-      "stimulus-reflex",
-      "sr"
-    ])
+    assert.deepEqual(registeredControllers(), ['stimulus-reflex', 'sr'])
 
     const element = await fixture(html`
       <div data-controller="sr">
@@ -36,16 +37,13 @@ describe('allReflexControllers', () => {
     `)
 
     const a = element.querySelector('a')
-    assert.deepEqual(identifiers(allReflexControllers(a)), ["sr"])
+    assert.deepEqual(identifiers(allReflexControllers(a)), ['sr'])
   })
 
   it('doesnt return regular controller from parent', async () => {
-    App.app.register("regular", RegularController)
+    App.app.register('regular', RegularController)
 
-    assert.deepEqual(registeredControllers(), [
-      "stimulus-reflex",
-      "regular"
-    ])
+    assert.deepEqual(registeredControllers(), ['stimulus-reflex', 'regular'])
 
     const element = await fixture(html`
       <div data-controller="regular">
@@ -58,10 +56,10 @@ describe('allReflexControllers', () => {
   })
 
   it('should return all reflex controllers from parents', async () => {
-    App.app.register("sr-one", ExampleController)
-    App.app.register("sr-two", ExampleController)
-    App.app.register("regular-one", RegularController)
-    App.app.register("regular-two", RegularController)
+    App.app.register('sr-one', ExampleController)
+    App.app.register('sr-two', ExampleController)
+    App.app.register('regular-one', RegularController)
+    App.app.register('regular-two', RegularController)
 
     const element = await fixture(html`
       <div data-controller="sr-one">
@@ -79,14 +77,11 @@ describe('allReflexControllers', () => {
 
     const controllers = allReflexControllers(a)
 
-    assert.deepEqual(identifiers(controllers), [
-      "sr-two",
-      "sr-one",
-    ])
+    assert.deepEqual(identifiers(controllers), ['sr-two', 'sr-one'])
   })
 
   it('should return controllers with same name', async () => {
-    App.app.register("sr", ExampleController)
+    App.app.register('sr', ExampleController)
 
     const outer = await fixture(html`
       <div data-controller="sr" id="outer">
@@ -100,10 +95,7 @@ describe('allReflexControllers', () => {
     const inner = outer.querySelector('#inner')
     const controllers = allReflexControllers(a)
 
-    assert.deepEqual(identifiers(controllers), [
-      "sr",
-      "sr",
-    ])
+    assert.deepEqual(identifiers(controllers), ['sr', 'sr'])
 
     assert.deepEqual(controllers[0].element, inner)
     assert.deepEqual(controllers[1].element, outer)

--- a/javascript/test/controllers.extractReflexName.test.js
+++ b/javascript/test/controllers.extractReflexName.test.js
@@ -5,7 +5,9 @@ import { findControllerByReflexName } from '../controllers'
 
 describe('findControllerByReflexName', () => {
   it('returns undefined if empty controllers array is passed', () => {
-    assert.isUndefined(findControllerByReflexName('click->TestReflex#create', []))
+    assert.isUndefined(
+      findControllerByReflexName('click->TestReflex#create', [])
+    )
     assert.isUndefined(findControllerByReflexName('click->Test#create', []))
   })
 
@@ -17,8 +19,12 @@ describe('findControllerByReflexName', () => {
       { identifier: 'last' }
     ]
 
-    assert.isUndefined(findControllerByReflexName('click->NoReflex#create', controllers))
-    assert.isUndefined(findControllerByReflexName('click->No#create', controllers))
+    assert.isUndefined(
+      findControllerByReflexName('click->NoReflex#create', controllers)
+    )
+    assert.isUndefined(
+      findControllerByReflexName('click->No#create', controllers)
+    )
   })
 
   it('returns matching controller', () => {

--- a/javascript/test/controllers.extractReflexName.test.js
+++ b/javascript/test/controllers.extractReflexName.test.js
@@ -11,7 +11,7 @@ describe('findControllerByReflexName', () => {
     )
   })
 
-  it('returns first controller if no matching controller is found', () => {
+  xit('returns first controller if no matching controller is found', () => {
     const controller = { identifier: 'test' }
     const controllers = [
       { identifier: 'first' },

--- a/javascript/test/controllers.extractReflexName.test.js
+++ b/javascript/test/controllers.extractReflexName.test.js
@@ -5,13 +5,11 @@ import { findControllerByReflexName } from '../controllers'
 
 describe('findControllerByReflexName', () => {
   it('returns undefined if empty controllers array is passed', () => {
-    assert.equal(
-      findControllerByReflexName('click->TestReflex#create', []),
-      undefined
-    )
+    assert.isUndefined(findControllerByReflexName('click->TestReflex#create', []))
+    assert.isUndefined(findControllerByReflexName('click->Test#create', []))
   })
 
-  xit('returns first controller if no matching controller is found', () => {
+  it('returns no controller if no matching controller is found', () => {
     const controller = { identifier: 'test' }
     const controllers = [
       { identifier: 'first' },
@@ -19,10 +17,8 @@ describe('findControllerByReflexName', () => {
       { identifier: 'last' }
     ]
 
-    assert.equal(
-      findControllerByReflexName('click->NoReflex#create', controllers),
-      controllers[0]
-    )
+    assert.isUndefined(findControllerByReflexName('click->NoReflex#create', controllers))
+    assert.isUndefined(findControllerByReflexName('click->No#create', controllers))
   })
 
   it('returns matching controller', () => {
@@ -35,6 +31,11 @@ describe('findControllerByReflexName', () => {
 
     assert.equal(
       findControllerByReflexName('click->TestReflex#create', controllers),
+      controller
+    )
+
+    assert.equal(
+      findControllerByReflexName('click->Test#create', controllers),
       controller
     )
   })
@@ -54,6 +55,14 @@ describe('findControllerByReflexName', () => {
       ),
       controller
     )
+
+    assert.equal(
+      findControllerByReflexName(
+        'click->Some::Deep::Module::Test#create',
+        controllers
+      ),
+      controller
+    )
   })
 
   it('returns dasherized controller', () => {
@@ -66,6 +75,11 @@ describe('findControllerByReflexName', () => {
 
     assert.equal(
       findControllerByReflexName('click->SomeThingReflex#create', controllers),
+      controller
+    )
+
+    assert.equal(
+      findControllerByReflexName('click->SomeThing#create', controllers),
       controller
     )
   })

--- a/javascript/test/controllers.localReflexControllers.test.js
+++ b/javascript/test/controllers.localReflexControllers.test.js
@@ -1,0 +1,79 @@
+import { html, fixture, assert, nextFrame, oneEvent } from '@open-wc/testing'
+
+import { application } from './dummy/application'
+import ExampleController from './dummy/example_controller'
+import RegularController from './dummy/regular_controller'
+
+import App from '../app'
+import { localReflexControllers } from '../controllers'
+import { initialize } from '../stimulus_reflex'
+
+import { unloadAllControllers, registeredControllers, identifiers } from './test_helpers'
+
+describe('localReflexControllers', () => {
+  beforeEach(() => {
+    initialize(application)
+  })
+
+  afterEach(() => {
+    unloadAllControllers()
+  })
+
+  it('returns StimulusReflex-enabled controller', async () => {
+    App.app.register("sr", ExampleController)
+
+    assert.deepEqual(registeredControllers(), [
+      "stimulus-reflex",
+      "sr"
+    ])
+
+    const element = await fixture(html`
+      <div data-controller="sr"></div>
+    `)
+
+    assert.deepEqual(identifiers(localReflexControllers(element)), ["sr"])
+  })
+
+  it('doesnt return regular controller', async () => {
+    App.app.register("sr", ExampleController)
+    App.app.register("regular", RegularController)
+
+    assert.deepEqual(registeredControllers(), [
+      "stimulus-reflex",
+      "sr",
+      "regular"
+    ])
+
+    const element = await fixture(html`
+      <div data-controller="sr regular"></div>
+    `)
+
+    assert.deepEqual(identifiers(localReflexControllers(element)), [
+      "sr"
+    ])
+  })
+
+  it('returns all StimulusReflex-enabled controllers', async () => {
+    App.app.register("sr-one", ExampleController)
+    App.app.register("sr-two", ExampleController)
+    App.app.register("regular-one", RegularController)
+    App.app.register("regular-two", RegularController)
+
+    assert.deepEqual(registeredControllers(), [
+      "stimulus-reflex",
+      "sr-one",
+      "sr-two",
+      "regular-one",
+      "regular-two"
+    ])
+
+    const element = await fixture(html`
+      <div data-controller="regular-two sr-two sr-one regular-one"></div>
+    `)
+
+    assert.deepEqual(identifiers(localReflexControllers(element)), [
+      "sr-two",
+      "sr-one"
+    ])
+  })
+})

--- a/javascript/test/controllers.localReflexControllers.test.js
+++ b/javascript/test/controllers.localReflexControllers.test.js
@@ -8,7 +8,11 @@ import App from '../app'
 import { localReflexControllers } from '../controllers'
 import { initialize } from '../stimulus_reflex'
 
-import { unloadAllControllers, registeredControllers, identifiers } from './test_helpers'
+import {
+  unloadAllControllers,
+  registeredControllers,
+  identifiers
+} from './test_helpers'
 
 describe('localReflexControllers', () => {
   beforeEach(() => {
@@ -20,51 +24,46 @@ describe('localReflexControllers', () => {
   })
 
   it('returns StimulusReflex-enabled controller', async () => {
-    App.app.register("sr", ExampleController)
+    App.app.register('sr', ExampleController)
 
-    assert.deepEqual(registeredControllers(), [
-      "stimulus-reflex",
-      "sr"
-    ])
+    assert.deepEqual(registeredControllers(), ['stimulus-reflex', 'sr'])
 
     const element = await fixture(html`
       <div data-controller="sr"></div>
     `)
 
-    assert.deepEqual(identifiers(localReflexControllers(element)), ["sr"])
+    assert.deepEqual(identifiers(localReflexControllers(element)), ['sr'])
   })
 
   it('doesnt return regular controller', async () => {
-    App.app.register("sr", ExampleController)
-    App.app.register("regular", RegularController)
+    App.app.register('sr', ExampleController)
+    App.app.register('regular', RegularController)
 
     assert.deepEqual(registeredControllers(), [
-      "stimulus-reflex",
-      "sr",
-      "regular"
+      'stimulus-reflex',
+      'sr',
+      'regular'
     ])
 
     const element = await fixture(html`
       <div data-controller="sr regular"></div>
     `)
 
-    assert.deepEqual(identifiers(localReflexControllers(element)), [
-      "sr"
-    ])
+    assert.deepEqual(identifiers(localReflexControllers(element)), ['sr'])
   })
 
   it('returns all StimulusReflex-enabled controllers', async () => {
-    App.app.register("sr-one", ExampleController)
-    App.app.register("sr-two", ExampleController)
-    App.app.register("regular-one", RegularController)
-    App.app.register("regular-two", RegularController)
+    App.app.register('sr-one', ExampleController)
+    App.app.register('sr-two', ExampleController)
+    App.app.register('regular-one', RegularController)
+    App.app.register('regular-two', RegularController)
 
     assert.deepEqual(registeredControllers(), [
-      "stimulus-reflex",
-      "sr-one",
-      "sr-two",
-      "regular-one",
-      "regular-two"
+      'stimulus-reflex',
+      'sr-one',
+      'sr-two',
+      'regular-one',
+      'regular-two'
     ])
 
     const element = await fixture(html`
@@ -72,8 +71,8 @@ describe('localReflexControllers', () => {
     `)
 
     assert.deepEqual(identifiers(localReflexControllers(element)), [
-      "sr-two",
-      "sr-one"
+      'sr-two',
+      'sr-one'
     ])
   })
 })

--- a/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
+++ b/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
@@ -323,17 +323,31 @@ describe('scanForReflexesOnElement', () => {
     assert.equal(button.dataset.controller, undefined)
   })
 
-  it('test', async () => {
-    App.app.register('tooltip', ExampleController)
+  it('should remove stimulus-reflex controller when other controller is a matching StimulusReflex-enabled controller', async () => {
+    App.app.register('example', ExampleController)
 
     const controllerElement = await fixture(html`
-      <i data-controller="tooltip stimulus-reflex" data-reflex="click->ThumbRating#rate!"></i>
+      <div data-controller="example stimulus-reflex" data-reflex="click->Example#else"></div>
     `)
 
     scanForReflexesOnElement(controllerElement)
 
-    assert.equal(controllerElement.dataset.controller, 'tooltip stimulus-reflex')
-    assert.equal(controllerElement.dataset.reflex, 'click->ThumbRating#rate!')
+    assert.equal(controllerElement.dataset.controller, 'example')
+    assert.equal(controllerElement.dataset.reflex, 'click->Example#else')
+    assert.equal(controllerElement.dataset.action, 'click->example#__perform')
+  })
+
+  it('should not remove stimulus-reflex controller when other controller is a non-matching StimulusReflex-enabled controller', async () => {
+    App.app.register('example', ExampleController)
+
+    const controllerElement = await fixture(html`
+      <div data-controller="example stimulus-reflex" data-reflex="click->Something#else"></div>
+    `)
+
+    scanForReflexesOnElement(controllerElement)
+
+    assert.equal(controllerElement.dataset.controller, 'example stimulus-reflex')
+    assert.equal(controllerElement.dataset.reflex, 'click->Something#else')
     assert.equal(controllerElement.dataset.action, 'click->stimulus-reflex#__perform')
   })
 })

--- a/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
+++ b/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
@@ -9,9 +9,7 @@ import { initialize } from '../stimulus_reflex'
 import App from '../app'
 import { scanForReflexesOnElement } from '../scanner'
 
-function registeredControllers () {
-  return Array.from(App.app.router.modulesByIdentifier.keys())
-}
+import { unloadAllControllers, registeredControllers } from './test_helpers'
 
 describe('scanForReflexesOnElement', () => {
   beforeEach(() => {
@@ -19,7 +17,7 @@ describe('scanForReflexesOnElement', () => {
   })
 
   afterEach(() => {
-    App.app.unload(registeredControllers())
+    unloadAllControllers()
   })
 
   it('should add the right action and controller attribute', async () => {

--- a/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
+++ b/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
@@ -325,7 +325,10 @@ describe('scanForReflexesOnElement', () => {
     App.app.register('example', ExampleController)
 
     const controllerElement = await fixture(html`
-      <div data-controller="example stimulus-reflex" data-reflex="click->Example#else"></div>
+      <div
+        data-controller="example stimulus-reflex"
+        data-reflex="click->Example#else"
+      ></div>
     `)
 
     scanForReflexesOnElement(controllerElement)
@@ -339,13 +342,22 @@ describe('scanForReflexesOnElement', () => {
     App.app.register('example', ExampleController)
 
     const controllerElement = await fixture(html`
-      <div data-controller="example stimulus-reflex" data-reflex="click->Something#else"></div>
+      <div
+        data-controller="example stimulus-reflex"
+        data-reflex="click->Something#else"
+      ></div>
     `)
 
     scanForReflexesOnElement(controllerElement)
 
-    assert.equal(controllerElement.dataset.controller, 'example stimulus-reflex')
+    assert.equal(
+      controllerElement.dataset.controller,
+      'example stimulus-reflex'
+    )
     assert.equal(controllerElement.dataset.reflex, 'click->Something#else')
-    assert.equal(controllerElement.dataset.action, 'click->stimulus-reflex#__perform')
+    assert.equal(
+      controllerElement.dataset.action,
+      'click->stimulus-reflex#__perform'
+    )
   })
 })

--- a/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
+++ b/javascript/test/reflexes.setupDeclarativeReflexesForElement.test.js
@@ -322,4 +322,18 @@ describe('scanForReflexesOnElement', () => {
     assert.equal(button.dataset.action, 'click->example#__perform')
     assert.equal(button.dataset.controller, undefined)
   })
+
+  it('test', async () => {
+    App.app.register('tooltip', ExampleController)
+
+    const controllerElement = await fixture(html`
+      <i data-controller="tooltip stimulus-reflex" data-reflex="click->ThumbRating#rate!"></i>
+    `)
+
+    scanForReflexesOnElement(controllerElement)
+
+    assert.equal(controllerElement.dataset.controller, 'tooltip stimulus-reflex')
+    assert.equal(controllerElement.dataset.reflex, 'click->ThumbRating#rate!')
+    assert.equal(controllerElement.dataset.action, 'click->stimulus-reflex#__perform')
+  })
 })

--- a/javascript/test/test_helpers.js
+++ b/javascript/test/test_helpers.js
@@ -1,0 +1,13 @@
+import App from '../app'
+
+export function registeredControllers () {
+  return Array.from(App.app.router.modulesByIdentifier.keys())
+}
+
+export function unloadAllControllers () {
+  App.app.unload(registeredControllers())
+}
+
+export function identifiers (controllers) {
+  return controllers.map(controller => controller.identifier)
+}


### PR DESCRIPTION
# Type of PR

Bug Fix

## Description

This pull request solves an edge-case for scenarios when StimulusReflex tries to detect the right controller to use for performing the StimulusReflex `__perform` controller action for executing reflexes.

For example, if an element had a `data-controller` and a `data-reflex` attribute, and the controller in `data-controller` was a StimulusReflex-enabled controller, but didn't match the Reflex specified in the `data-reflex` there were some cases where it wouldn't add the default `stimulus-reflex` controller to the element, but would still reference the `stimulus-reflex` controller in the `data-action` attribute. This basically lead to a no-op for the reflex action.

Like:
```html
<a
  data-controller="
    some-sr-controller
  "
  data-reflex="click->Example#doSomething"
></a>
```

was expanded to this in some cases:
```diff
<a
  data-controller="
    some-sr-controller
  "
  data-reflex="click->Example#doSomething"
+ data-action="click->stimulus-reflex#__perform"
></a>
```

Whereas it should have been:
```diff
<a
  data-controller="
    some-sr-controller
+   stimulus-reflex
  "
  data-reflex="click->Example#doSomething"
+ data-action="click->stimulus-reflex#__perform"
></a>
```
With this, the `data-action` is not referencing an undefined Stimulus controller anymore and the reflex should execute again.

## Why should this be added

For consitancy reasons, so that the declarative reflex syntax still continues to make sense and work as expected.

Maybe this is even fixing @Laykou's issue in #659 which I couldn't reproduce.

Thanks to @foliosus for helping to debug this! 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
