### PR TITLE
Export `StimulusReflexController` constant 

### DIFF
--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -32,7 +32,7 @@ import {
 // that have configured data-reflex. Note that this default can be overridden when initializing the application.
 // i.e. StimulusReflex.initialize(myStimulusApplication, MyCustomDefaultController)
 //
-class StimulusReflexController extends Controller {
+export class StimulusReflexController extends Controller {
   constructor (...args) {
     super(...args)
     register(this)


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

This pull request exports the `StimulusReflexController` constant so it can be imported from the `stimulus_reflex` package.

## Why should this be added

We already allow developers to customize the default controller used for the `stimulus-reflex` identifier by passing in the `controller` option in the `StimulusReflex.initialize(application, options)` call. 

This pull requests now allows developers to base  their default controller off the StimulusReflex controller by inheriting from the `StimulusReflexController` constant, like:

```js
// controllers/default_controller.js
import { StimulusReflexController } from "stimulus_reflex"

export default class extends StimulusReflexController {
  // extend the `stimulus-reflex` controller
}
```

and:
```js
import DefaultController from "../controllers/default_controller"

StimulusReflex.initialize(application, { controller: DefaultController })
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
