### PR TITLE
Fix `reflex_data` keyword argument

### DIFF
--- a/app/channels/stimulus_reflex/channel.rb
+++ b/app/channels/stimulus_reflex/channel.rb
@@ -16,13 +16,14 @@ class StimulusReflex::Channel < StimulusReflex.configuration.parent_channel.cons
       delegate_call_to_reflex reflex
     rescue => exception
       error = exception_with_backtrace(exception)
-      error_message = "\e[31mReflex #{reflex.data.target} failed: #{error[:message]} [#{reflex.url}]\e[0m\n#{error[:stack]}"
 
       if reflex
+        error_message = "\e[31mReflex #{reflex.data.target} failed: #{error[:message]} [#{reflex.url}]\e[0m\n#{error[:stack]}"
         reflex.rescue_with_handler(exception)
         reflex.logger&.error error_message
         reflex.broadcast_error data: data, error: "#{exception} #{exception.backtrace.first.split(":in ")[0] if Rails.env.development?}"
       else
+        error_message = "\e[31mReflex failed: #{error[:message]} \e[0m\n#{error[:stack]}"
         unless exception.is_a?(StimulusReflex::VersionMismatchError)
           StimulusReflex.config.logger.error error_message
         end

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -12,21 +12,22 @@ class StimulusReflex::Reflex
   include CableReady::Identifiable
 
   attr_accessor :payload, :headers
-  attr_reader :channel, :data, :broadcaster
+  attr_reader :channel, :reflex_data, :broadcaster
 
   delegate :connection, :stream_name, to: :channel
   delegate :controller_class, :flash, :session, to: :request
   delegate :broadcast, :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
 
   # TODO remove xpath_controller and xpath_element for v4
-  delegate :url, :element, :selectors, :method_name, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :npm_version, :suppress_logging, to: :data
+  delegate :url, :element, :selectors, :method_name, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :npm_version, :suppress_logging, to: :reflex_data
   # END TODO: remove
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
+  alias_method :data, :reflex_data
 
-  def initialize(channel, data:)
+  def initialize(channel, reflex_data:)
     @channel = channel
-    @data = data
+    @reflex_data = reflex_data
     @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     @payload = {}
     @headers = {}
@@ -75,7 +76,7 @@ class StimulusReflex::Reflex
       req = ActionDispatch::Request.new(env)
 
       # fetch path params (controller, action, ...) and apply them
-      request_params = StimulusReflex::RequestParameters.new(params: data.params, req: req, url: url)
+      request_params = StimulusReflex::RequestParameters.new(params: reflex_data.params, req: req, url: url)
       req = request_params.apply!
 
       req

--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -12,21 +12,21 @@ class StimulusReflex::Reflex
   include CableReady::Identifiable
 
   attr_accessor :payload, :headers
-  attr_reader :channel, :reflex_data, :broadcaster
+  attr_reader :channel, :data, :broadcaster
 
   delegate :connection, :stream_name, to: :channel
   delegate :controller_class, :flash, :session, to: :request
   delegate :broadcast, :broadcast_halt, :broadcast_forbid, :broadcast_error, to: :broadcaster
 
   # TODO remove xpath_controller and xpath_element for v4
-  delegate :url, :element, :selectors, :method_name, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :npm_version, :suppress_logging, to: :reflex_data
+  delegate :url, :element, :selectors, :method_name, :id, :tab_id, :reflex_controller, :xpath_controller, :xpath_element, :permanent_attribute_name, :version, :npm_version, :suppress_logging, to: :data
   # END TODO: remove
 
   alias_method :action_name, :method_name # for compatibility with controller libraries like Pundit that expect an action name
 
-  def initialize(channel, reflex_data:)
+  def initialize(channel, data:)
     @channel = channel
-    @reflex_data = reflex_data
+    @data = data
     @broadcaster = StimulusReflex::PageBroadcaster.new(self)
     @payload = {}
     @headers = {}
@@ -75,7 +75,7 @@ class StimulusReflex::Reflex
       req = ActionDispatch::Request.new(env)
 
       # fetch path params (controller, action, ...) and apply them
-      request_params = StimulusReflex::RequestParameters.new(params: reflex_data.params, req: req, url: url)
+      request_params = StimulusReflex::RequestParameters.new(params: data.params, req: req, url: url)
       req = request_params.apply!
 
       req

--- a/lib/stimulus_reflex/reflex_factory.rb
+++ b/lib/stimulus_reflex/reflex_factory.rb
@@ -11,7 +11,7 @@ class StimulusReflex::ReflexFactory
   end
 
   def call
-    reflex_class.new(channel, data: data)
+    reflex_class.new(channel, reflex_data: data)
   end
 
   private


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
bug fix

## Description
Rename named parameter, and change error message that was causing an exception in a rescue block.

## Why should this be added

Stimulus reflex doesn't work at all without these fixes.

## Checklist

- [X ] My code follows the style guidelines of this project
- [ X] Checks (StandardRB & Prettier-Standard) are passing
