### PR TITLE
Properly handle HTML fragments with self closing tags

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.15.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-linux)
@@ -202,6 +204,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-22
   x86_64-linux

--- a/lib/stimulus_reflex/html/document.rb
+++ b/lib/stimulus_reflex/html/document.rb
@@ -28,15 +28,11 @@ module StimulusReflex
       end
 
       def parse_html(html)
-        parsing_class.parse(html.to_s)
+        Nokogiri::HTML5::Document.parse(html.to_s)
       end
 
       def empty?
         @document.content.empty?
-      end
-
-      def parsing_class
-        Nokogiri::HTML5::Document
       end
 
       def match(selector)

--- a/lib/stimulus_reflex/html/document.rb
+++ b/lib/stimulus_reflex/html/document.rb
@@ -21,10 +21,14 @@ module StimulusReflex
       end
 
       def initialize(html)
-        @document = parsing_class.parse(html.to_s)
+        @document = parse_html(html)
         @matches = {
           "body" => Match.new(@document.at_css("body"))
         }
+      end
+
+      def parse_html(html)
+        parsing_class.parse(html.to_s)
       end
 
       def empty?

--- a/lib/stimulus_reflex/html/document_fragment.rb
+++ b/lib/stimulus_reflex/html/document_fragment.rb
@@ -5,8 +5,20 @@
 module StimulusReflex
   module HTML
     class DocumentFragment < Document
+      SELF_CLOSING_TAGS = %w[area base br col embed hr img input link meta param source track wbr].freeze
+
       def parsing_class
         Nokogiri
+      end
+
+      def parse_html(html)
+        html_string = fix_self_closing_tags(html.to_s)
+        parsing_class.parse(html_string)
+      end
+
+      def fix_self_closing_tags(html_string)
+        html_string.gsub(/(<(#{SELF_CLOSING_TAGS.join("|")})(\s+[^>]*[^>\/])*\s*)(?:>)/, '\1/>')
+                   .gsub(/<\/(#{SELF_CLOSING_TAGS.join("|")})\s*>/, '')
       end
     end
   end

--- a/lib/stimulus_reflex/html/document_fragment.rb
+++ b/lib/stimulus_reflex/html/document_fragment.rb
@@ -7,13 +7,9 @@ module StimulusReflex
     class DocumentFragment < Document
       SELF_CLOSING_TAGS = %w[area base br col embed hr img input link meta param source track wbr].freeze
 
-      def parsing_class
-        Nokogiri
-      end
-
       def parse_html(html)
         html_string = fix_self_closing_tags(html.to_s)
-        parsing_class.parse(html_string)
+        Nokogiri.parse(html_string)
       end
 
       def fix_self_closing_tags(html_string)

--- a/lib/stimulus_reflex/html/document_fragment.rb
+++ b/lib/stimulus_reflex/html/document_fragment.rb
@@ -18,7 +18,7 @@ module StimulusReflex
 
       def fix_self_closing_tags(html_string)
         html_string.gsub(/(<(#{SELF_CLOSING_TAGS.join("|")})(\s+[^>]*[^>\/])*\s*)(?:>)/, '\1/>')
-                   .gsub(/<\/(#{SELF_CLOSING_TAGS.join("|")})\s*>/, '')
+          .gsub(/<\/(#{SELF_CLOSING_TAGS.join("|")})\s*>/, "")
       end
     end
   end

--- a/test/html/document_fragment_test.rb
+++ b/test/html/document_fragment_test.rb
@@ -230,4 +230,32 @@ class StimulusReflex::HTML::DocumentFragmentTest < ActiveSupport::TestCase
     assert_equal "<li>1</li>", fragment.outer_html.squish
     assert_equal "1", fragment.inner_html.squish
   end
+
+  test "should properly parse unclosed input with sibling tags" do
+    raw_html = "<div><label><input type=\"file\"><span></span></label></div>"
+    fragment = StimulusReflex::HTML::DocumentFragment.new(raw_html)
+    assert_equal "<div><label><input type=\"file\"><span></span></label></div>", fragment.to_html.squish
+    assert_equal "<div><label><input type=\"file\"><span></span></label></div>", fragment.outer_html.squish
+  end
+
+  test "should properly parse unclosed img with sibling tags" do
+    raw_html = "<div><label><img src=\"file\"><span></span></label></div>"
+    fragment = StimulusReflex::HTML::DocumentFragment.new(raw_html)
+    assert_equal "<div><label><img src=\"file\"><span></span></label></div>", fragment.to_html.squish
+    assert_equal "<div><label><img src=\"file\"><span></span></label></div>", fragment.outer_html.squish
+  end
+
+  test "should properly parse unclosed br with sibling tags" do
+    raw_html = "<div><label><br><span></span></label></div>"
+    fragment = StimulusReflex::HTML::DocumentFragment.new(raw_html)
+    assert_equal "<div><label><br><span></span></label></div>", fragment.to_html.squish
+    assert_equal "<div><label><br><span></span></label></div>", fragment.outer_html.squish
+  end
+
+  test "should properly parse img with closing tag" do
+    raw_html = "<div><label><img src=\"file\"></img><span></span></label></div>"
+    fragment = StimulusReflex::HTML::DocumentFragment.new(raw_html)
+    assert_equal "<div><label><img src=\"file\"><span></span></label></div>", fragment.to_html.squish
+    assert_equal "<div><label><img src=\"file\"><span></span></label></div>", fragment.outer_html.squish
+  end
 end


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug Fix

## Description

Properly handle HTML fragments including self closing tags like `img`, `br`, `input` that Nokogiri XML parser would normally 
try to fix by adding a closing tag. For example, `<div><img src='x'><span>test</span></div>` would be changed internally to `<div><img src='x'><span>test</span></img></div>` by Nokogiri and then converted to `<div><img src='x'></div>` by Nokogiri through the `to_html` method. 

This is due to the use of `Nokogiri` parser for the selector morphs (as opposed to `Nokogiri::HTML5::Document` parser), but we cannot use the `Nokogiri::HTML5::Document` when handling incomplete HTML documents (see https://github.com/stimulusreflex/stimulus_reflex/commit/69cb070ec961dd52d34ec9a66a88f895686100c1 for more info)

One could say that we should produce valid html with `/` at the end of self-closing tags (ie: `<br/>` instead of `<br>`) but Nokogiri itself strips the trailling `/` when producing html string from XML nodes...

This PR detects these instances and handle them gracefully.

Fixes #652 (issue)

## Why should this be added

The main issue for the user before this PR is that html tags are sometimes removed from the reflex response because of this behaviour.

This PR allows Stimulus Reflex users to apply selector morphs with HTML containing self-closing tags with siblings.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
