### PR TITLE
Fix undefined package_json during Yarn install

### DIFF
--- a/lib/install/yarn.rb
+++ b/lib/install/yarn.rb
@@ -13,7 +13,7 @@ add = package_list.exist? ? package_list.readlines.map(&:chomp) : []
 dev = dev_package_list.exist? ? dev_package_list.readlines.map(&:chomp) : []
 drop = drop_package_list.exist? ? drop_package_list.readlines.map(&:chomp) : []
 
-json = JSON.parse(package_json.read)
+json = JSON.parse(package_json_path.read)
 
 if add.present? || dev.present? || drop.present?
 


### PR DESCRIPTION
# Type of PR
Bug fix

## Description

When running `rails stimulus_reflex:install` on a new Rails app using Yarn & esbuild, the following error is raised:

```
  --- [yarn] ----
  rails aborted!
  NameError: undefined local variable or method `package_json'
  for #<Rails::Generators::AppGenerator...
```

Looks like it's a missing update from
https://github.com/stimulusreflex/stimulus_reflex/pull/655

## Why should this be added
Setup raises errors at the Yarn step

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
