### PR TITLE
Explicitly require `ostruct` for `StimulusReflex::Dataset`

### DIFF
--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -3,6 +3,7 @@
 require "uri"
 require "open-uri"
 require "rack"
+require "ostruct"
 require "active_support/all"
 require "action_dispatch"
 require "action_cable"

--- a/lib/stimulus_reflex/dataset.rb
+++ b/lib/stimulus_reflex/dataset.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
 require "stimulus_reflex/utils/attribute_builder"
 
 class StimulusReflex::Dataset < OpenStruct

--- a/lib/stimulus_reflex/dataset.rb
+++ b/lib/stimulus_reflex/dataset.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "ostruct"
 require "stimulus_reflex/utils/attribute_builder"
 
 class StimulusReflex::Dataset < OpenStruct


### PR DESCRIPTION
# Type of PR

Bug Fix

## Description

From #695:

> [Rubocop v1.63.0](https://github.com/rubocop/rubocop/releases/tag/v1.63.0) updates [json to v2.7.2](https://github.com/flori/json/releases/tag/v2.7.2). json v2.7.2 https://github.com/flori/json/pull/565. StimulusReflex relies on OpenStruct in both the [Dataset](https://github.com/stimulusreflex/stimulus_reflex/blob/3a5111e085b21d1e628813e2cee72e978acb257a/lib/stimulus_reflex/dataset.rb#L5) and the [Element](https://github.com/stimulusreflex/stimulus_reflex/blob/3a5111e085b21d1e628813e2cee72e978acb257a/lib/stimulus_reflex/element.rb#L6) models. Attempting to run rails, ie a rails console, results in the error

Fixes #695 

## Why should this be added

Makes applications and CI run again.

We should think about migrating off of `OpenStruct`, but this PR should make it work for now as a work-around.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
