### PR TITLE
Add Thor require for `StimulusReflex::Installer`

### DIFF
--- a/lib/stimulus_reflex/installer.rb
+++ b/lib/stimulus_reflex/installer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "thor"
+
 module StimulusReflex
   class Installer
     include Thor::Base


### PR DESCRIPTION
## Description

Rake tasks were failing in projects because the required Thor dependency was not always required, depending on the way it was called.

The fix also needed to explicitly require the thor gem in the installer file that used it as a mixin.

Fixes https://github.com/stimulusreflex/stimulus_reflex/issues/701

## Why should this be added

Rake tasks in Rails applications were no longer working with the latest version of this Gem.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
