### PR TITLE
work on rails 8 and future versions

### DIFF
--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.0.0"
 
-  rails_version = [">= 5.2", "< 8"]
+  rails_version = [">= 5.2"]
   gem.add_dependency "actioncable", *rails_version
   gem.add_dependency "actionpack", *rails_version
   gem.add_dependency "actionview", *rails_version


### PR DESCRIPTION
Installing stimulus reflex on Rails 8.0 was failing, this change will get it to install. 
