### PR TITLE
Declare dependency on ostruct in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       cable_ready (~> 5.0)
       nokogiri (~> 1.0)
       nokogiri-html5-inference (~> 0.3)
+      ostruct (~> 0.6)
       rack (>= 2, < 4)
       railties (>= 5.2)
       redis (>= 4.0, < 6.0)
@@ -146,6 +147,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.17.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.17.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.17.2-x86_64-linux)
@@ -153,6 +156,7 @@ GEM
     nokogiri-html5-inference (0.3.0)
       nokogiri (~> 1.14)
     observer (0.1.2)
+    ostruct (0.6.1)
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
@@ -243,6 +247,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-22
   x86_64-darwin-23

--- a/stimulus_reflex.gemspec
+++ b/stimulus_reflex.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack", ">= 2", "< 4"
   gem.add_dependency "redis", ">= 4.0", "< 6.0"
   gem.add_dependency "nokogiri-html5-inference", "~> 0.3"
+  gem.add_dependency "ostruct", "~> 0.6"
 
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "magic_frozen_string_literal", "~> 1.2"


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Warning fix

## Description
The absence of this declaration in `stimulus_reflex.gemspec` was emitting this warning in projects using this library:

> warning: .rubies/ruby-3.4.2/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add ostruct to your Gemfile or gemspec to silence this warning. Also please contact the author of stimulus_reflex-3.5.3 to request adding ostruct into its gemspec.


Related to #695, #698 

## Why should this be added
I know that the long-term goal is to move away from using ostruct entirely, but since it's still used in the meantime, this feels like a reasonable thing to do.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] Checks (StandardRB & Prettier-Standard) are passing
